### PR TITLE
feat: implement WORKFLOW.md loader (#3)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from "./model/work-item.js";
 export * from "./orchestrator/runtime.js";
 export * from "./tracker/adapter.js";
 export * from "./workflow/contract.js";
+export * from "./workflow/loader.js";

--- a/src/workflow/loader.test.ts
+++ b/src/workflow/loader.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  WorkflowParseError,
+  WorkflowValidationError,
+  loadWorkflowFile,
+  parseWorkflowMarkdown,
+} from "./loader.js";
+
+test("parses front matter and trims prompt body", () => {
+  const doc = parseWorkflowMarkdown(`---\nname: demo\ncount: 3\n---\n\n  hello prompt\n\n`);
+
+  assert.deepEqual(doc.config, { name: "demo", count: 3 });
+  assert.equal(doc.prompt_template, "hello prompt");
+});
+
+test("returns empty config when front matter is absent", () => {
+  const doc = parseWorkflowMarkdown("\n\njust prompt\n\n");
+
+  assert.deepEqual(doc.config, {});
+  assert.equal(doc.prompt_template, "just prompt");
+});
+
+test("throws WorkflowParseError when front matter is malformed", () => {
+  assert.throws(
+    () => parseWorkflowMarkdown("---\nname: demo\nbody without closer"),
+    WorkflowParseError,
+  );
+});
+
+test("throws WorkflowValidationError when front matter is not an object", () => {
+  assert.throws(
+    () => parseWorkflowMarkdown("---\n- item\n---\ntext"),
+    WorkflowValidationError,
+  );
+});
+
+test("loadWorkflowFile reads explicit path", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "workflow-loader-"));
+  const filePath = join(dir, "WORKFLOW.md");
+  await writeFile(filePath, "---\nname: from-file\n---\n\nbody\n", "utf8");
+
+  const doc = await loadWorkflowFile(filePath);
+  assert.deepEqual(doc.config, { name: "from-file" });
+  assert.equal(doc.prompt_template, "body");
+});

--- a/src/workflow/loader.ts
+++ b/src/workflow/loader.ts
@@ -1,0 +1,112 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+export type WorkflowConfig = Record<string, unknown>;
+
+export interface WorkflowDocument {
+  config: WorkflowConfig;
+  prompt_template: string;
+}
+
+export class WorkflowLoadError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "WorkflowLoadError";
+  }
+}
+
+export class WorkflowParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkflowParseError";
+  }
+}
+
+export class WorkflowValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkflowValidationError";
+  }
+}
+
+export async function loadWorkflowFile(path?: string): Promise<WorkflowDocument> {
+  const workflowPath = path ? resolve(path) : resolve(process.cwd(), "WORKFLOW.md");
+
+  let raw: string;
+  try {
+    raw = await readFile(workflowPath, "utf8");
+  } catch (error) {
+    throw new WorkflowLoadError(`Failed to read WORKFLOW.md: ${workflowPath}`, { cause: error });
+  }
+
+  return parseWorkflowMarkdown(raw);
+}
+
+export function parseWorkflowMarkdown(input: string): WorkflowDocument {
+  const normalized = input.replace(/\r\n/g, "\n");
+
+  if (!normalized.startsWith("---\n")) {
+    return {
+      config: {},
+      prompt_template: normalized.trim(),
+    };
+  }
+
+  const closingIndex = normalized.indexOf("\n---\n", 4);
+  if (closingIndex < 0) {
+    throw new WorkflowParseError("Malformed front matter: missing closing delimiter");
+  }
+
+  const frontMatterText = normalized.slice(4, closingIndex).trim();
+  const markdownBody = normalized.slice(closingIndex + 5);
+  const config = parseYamlObject(frontMatterText);
+
+  return {
+    config,
+    prompt_template: markdownBody.trim(),
+  };
+}
+
+function parseYamlObject(text: string): WorkflowConfig {
+  if (text.length === 0) {
+    return {};
+  }
+
+  const result: WorkflowConfig = {};
+
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    if (trimmed.startsWith("-") || trimmed.startsWith("[") || trimmed.startsWith("{")) {
+      throw new WorkflowValidationError("Front matter must be a YAML object");
+    }
+
+    const match = trimmed.match(/^([A-Za-z0-9_-]+)\s*:\s*(.*)$/);
+    if (!match) {
+      throw new WorkflowParseError(`Malformed front matter line: ${line}`);
+    }
+
+    const [, key, rawValue] = match;
+    result[key] = parseScalar(rawValue);
+  }
+
+  return result;
+}
+
+function parseScalar(value: string): unknown {
+  const v = value.trim();
+
+  if (v === "") return "";
+  if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+    return v.slice(1, -1);
+  }
+  if (v === "true") return true;
+  if (v === "false") return false;
+  if (v === "null") return null;
+  if (/^-?\d+(\.\d+)?$/.test(v)) return Number(v);
+
+  return v;
+}


### PR DESCRIPTION
## Summary
- implement `loadWorkflowFile` for `WORKFLOW.md` (explicit path or cwd default)
- parse YAML-like front matter + markdown body into `{ config, prompt_template }`
- add dedicated parse/validation error types and unit tests

## Quality Gate
- npm run typecheck
- npm run build
- npm test

Closes #3
