### PR TITLE
feat: issue #5 normalized work-item model

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,7 @@ npm test
 
 ## Notes
 
+- Work-item normalization rules: `docs/work-item-model.md`
+
 This repo follows the direction in Symphony SPEC:
 <https://github.com/openai/symphony/blob/main/SPEC.md>

--- a/docs/work-item-model.md
+++ b/docs/work-item-model.md
@@ -1,0 +1,41 @@
+# WorkItem 正規化モデル（GitHub Projects）
+
+## 目的
+GitHub Project item と紐づく Issue/PR を、実行系が扱いやすい `WorkItem` に正規化する。
+
+## 正規化後の型
+- `id`: 内部一意ID（GitHub node id）
+- `identifier`: 人間可読ID（`owner/repo#number`）
+- `title`: タイトル
+- `description`: 本文（未設定時は空文字）
+- `priority`: 優先度（任意）
+- `state`: `todo | in_progress | blocked | done`
+- `labels`: ラベル名配列
+- `url`: Issue/PR URL
+- `blocked_by`: 依存元 ID 配列（文字列）
+
+## マッピングルール
+1. `identifier` は `repositorySlug + # + number`
+2. `state` は以下で正規化
+   - 入力は `trim + lowercase`
+   - エイリアス変換
+     - `todo/backlog/to do/open` → `todo`
+     - `in progress/in_progress/doing` → `in_progress`
+     - `blocked` → `blocked`
+     - `done/closed` → `done`
+   - 不明値は `todo`
+3. `state` 優先順位
+   - project status があればそれを採用
+   - なければ linked issue/pr state を採用
+4. `blocked_by` は number/string 混在を文字列に統一
+
+## workspace key サニタイズ戦略
+`sanitizeWorkspaceKey` で以下を適用:
+- 前後空白を除去
+- 小文字化
+- 英数字以外を `-` へ置換
+- 連続記号や先頭末尾の `-` を除去
+
+例:
+- `"  Team A / Sprint 1  "` → `"team-a-sprint-1"`
+- `"Feature:Auth#Core"` → `"feature-auth-core"`

--- a/src/model/work-item.test.ts
+++ b/src/model/work-item.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeState, sanitizeWorkspaceKey } from "./work-item.js";
+
+test("normalizeState trims + lowercases and maps aliases", () => {
+  assert.equal(normalizeState("  In Progress  "), "in_progress");
+  assert.equal(normalizeState("CLOSED"), "done");
+  assert.equal(normalizeState(" backlog "), "todo");
+});
+
+test("normalizeState falls back to todo for unknown values", () => {
+  assert.equal(normalizeState("needs-triage"), "todo");
+  assert.equal(normalizeState(undefined), "todo");
+});
+
+test("sanitizeWorkspaceKey normalizes separators", () => {
+  assert.equal(sanitizeWorkspaceKey("  Team A / Sprint 1  "), "team-a-sprint-1");
+  assert.equal(sanitizeWorkspaceKey("Feature:Auth#Core"), "feature-auth-core");
+});

--- a/src/model/work-item.ts
+++ b/src/model/work-item.ts
@@ -1,13 +1,76 @@
 export type WorkItemState = "todo" | "in_progress" | "blocked" | "done";
 
-export interface NormalizedWorkItem {
+export interface WorkItem {
   id: string;
-  number?: number;
+  identifier: string;
   title: string;
-  body?: string;
+  description: string;
+  priority?: string;
   state: WorkItemState;
   labels: string[];
-  assignees: string[];
-  url?: string;
-  updatedAt: string;
+  url: string;
+  blocked_by: string[];
+}
+
+export type NormalizedWorkItem = WorkItem;
+
+export interface GitHubLinkedContent {
+  id: string;
+  number: number;
+  title: string;
+  body?: string | null;
+  state?: string | null;
+  labels?: string[];
+  url: string;
+}
+
+export interface GitHubProjectItem {
+  id: string;
+  priority?: string | null;
+  status?: string | null;
+  blockedBy?: Array<string | number>;
+  content: GitHubLinkedContent;
+}
+
+const STATE_ALIASES: Record<string, WorkItemState> = {
+  todo: "todo",
+  backlog: "todo",
+  "to do": "todo",
+  open: "todo",
+  "in progress": "in_progress",
+  in_progress: "in_progress",
+  doing: "in_progress",
+  blocked: "blocked",
+  done: "done",
+  closed: "done",
+};
+
+export function normalizeState(raw: string | undefined | null): WorkItemState {
+  const normalized = (raw ?? "").trim().toLowerCase();
+  return STATE_ALIASES[normalized] ?? "todo";
+}
+
+export function sanitizeWorkspaceKey(raw: string): string {
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function toWorkItem(item: GitHubProjectItem, repositorySlug: string): WorkItem {
+  const fallbackState = normalizeState(item.content.state);
+  const projectState = normalizeState(item.status);
+
+  return {
+    id: item.content.id,
+    identifier: `${repositorySlug}#${item.content.number}`,
+    title: item.content.title,
+    description: item.content.body ?? "",
+    priority: item.priority ?? undefined,
+    state: item.status ? projectState : fallbackState,
+    labels: item.content.labels ?? [],
+    url: item.content.url,
+    blocked_by: (item.blockedBy ?? []).map((v) => String(v)),
+  };
 }


### PR DESCRIPTION
## Target Issue
- Closes #5

## Changes
- Implemented types and mapper (`toWorkItem`) to normalize GitHub Projects items + linked issue/PR into `WorkItem`
- Implemented state normalization with `trim + lowercase` and alias conversion (`normalizeState`)
- Implemented workspace-key sanitization (`sanitizeWorkspaceKey`)
- Added mapping spec and examples in `docs/work-item-model.md`
- Added unit tests for normalization helpers

## Quality Gates
- `npm run typecheck` ✅
- `npm run build` ✅
- `npm test` ✅
- `npm run lint` ❌ (script not defined yet)