### PR TITLE
feat: implement GitHub Projects read adapter (Issue #6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "symphony-github-projects",
       "version": "0.1.0",
       "devDependencies": {
-        "@types/node": "^22.19.15",
+        "@types/node": "^25.3.5",
         "typescript": "^5.8.2"
       },
       "engines": {
@@ -16,13 +16,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "25.3.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
+      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/typescript": {
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=20"
   },
   "devDependencies": {
-    "@types/node": "^22.19.15",
+    "@types/node": "^25.3.5",
     "typescript": "^5.8.2"
   }
 }

--- a/src/tracker/adapter.test.ts
+++ b/src/tracker/adapter.test.ts
@@ -1,0 +1,156 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { GitHubProjectsAdapter } from "./adapter.js";
+
+test("fetchEligibleItems paginates and filters by active states", async () => {
+  const calls: Array<string | null> = [];
+
+  const fetchImpl: typeof fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    const after = body.variables.after as string | null;
+    calls.push(after);
+
+    const page1 = {
+      data: {
+        user: {
+          projectV2: {
+            items: {
+              nodes: [
+                makeNode({ issueId: "ISSUE_1", number: 101, status: "Todo", issueState: "OPEN" }),
+                makeNode({ issueId: "ISSUE_2", number: 102, status: "Done", issueState: "OPEN" }),
+              ],
+              pageInfo: { hasNextPage: true, endCursor: "CURSOR_1" },
+            },
+          },
+        },
+        organization: null,
+      },
+    };
+
+    const page2 = {
+      data: {
+        user: {
+          projectV2: {
+            items: {
+              nodes: [
+                makeNode({ issueId: "ISSUE_3", number: 103, status: "In Progress", issueState: "OPEN" }),
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+        organization: null,
+      },
+    };
+
+    return new Response(JSON.stringify(after ? page2 : page1), { status: 200 });
+  }) as typeof fetch;
+
+  const adapter = new GitHubProjectsAdapter({
+    owner: "kouka-t0yohei",
+    projectNumber: 7,
+    token: "dummy",
+    activeStates: ["todo", "in_progress"],
+    fetchImpl,
+    pageSize: 2,
+  });
+
+  const eligible = await adapter.fetchEligibleItems();
+
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls, [null, "CURSOR_1"]);
+  assert.deepEqual(
+    eligible.map((item) => item.number),
+    [101, 103],
+  );
+});
+
+test("fetchByIssueNumbers returns only matched issue numbers", async () => {
+  const fetchImpl: typeof fetch = (async () => {
+    const body = {
+      data: {
+        user: {
+          projectV2: {
+            items: {
+              nodes: [
+                makeNode({ issueId: "ISSUE_7", number: 201, status: "Todo", issueState: "OPEN" }),
+                makeNode({ issueId: "ISSUE_8", number: 202, status: "In Progress", issueState: "OPEN" }),
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+        organization: null,
+      },
+    };
+
+    return new Response(JSON.stringify(body), { status: 200 });
+  }) as typeof fetch;
+
+  const adapter = new GitHubProjectsAdapter({
+    owner: "kouka-t0yohei",
+    projectNumber: 7,
+    token: "dummy",
+    activeStates: ["todo"],
+    fetchImpl,
+  });
+
+  const reconciled = await adapter.fetchByIssueNumbers([202]);
+  assert.equal(reconciled.length, 1);
+  assert.equal(reconciled[0]?.number, 202);
+});
+
+test("throws on GraphQL errors", async () => {
+  const fetchImpl: typeof fetch = (async () => {
+    return new Response(
+      JSON.stringify({
+        data: null,
+        errors: [{ message: "API rate limit exceeded" }],
+      }),
+      { status: 200 },
+    );
+  }) as typeof fetch;
+
+  const adapter = new GitHubProjectsAdapter({
+    owner: "kouka-t0yohei",
+    projectNumber: 7,
+    token: "dummy",
+    activeStates: ["todo"],
+    fetchImpl,
+  });
+
+  await assert.rejects(async () => adapter.fetchEligibleItems(), /rate limit exceeded/i);
+});
+
+function makeNode(input: {
+  issueId: string;
+  number: number;
+  status: string;
+  issueState: "OPEN" | "CLOSED";
+}) {
+  return {
+    id: `PITEM_${input.number}`,
+    fieldValues: {
+      nodes: [
+        {
+          __typename: "ProjectV2ItemFieldSingleSelectValue",
+          name: input.status,
+          field: { name: "Status" },
+        },
+      ],
+    },
+    content: {
+      __typename: "Issue",
+      id: input.issueId,
+      number: input.number,
+      title: `Issue ${input.number}`,
+      body: "",
+      url: `https://github.com/kouka-t0yohei/symphony-github-projects/issues/${input.number}`,
+      updatedAt: "2026-03-06T00:00:00Z",
+      state: input.issueState,
+      labels: { nodes: [] },
+      assignees: { nodes: [] },
+    },
+  };
+}

--- a/src/tracker/adapter.ts
+++ b/src/tracker/adapter.ts
@@ -1,4 +1,7 @@
-import type { NormalizedWorkItem } from "../model/work-item.js";
+import type { Logger } from "../logging/logger.js";
+import type { NormalizedWorkItem, WorkItemState } from "../model/work-item.js";
+
+type FetchLike = typeof fetch;
 
 export interface TrackerAdapter {
   listEligibleItems(): Promise<NormalizedWorkItem[]>;
@@ -6,9 +9,195 @@ export interface TrackerAdapter {
   markDone(itemId: string): Promise<void>;
 }
 
-export class GitHubProjectsAdapterPlaceholder implements TrackerAdapter {
+export interface GitHubProjectsAdapterOptions {
+  owner: string;
+  projectNumber: number;
+  token: string;
+  activeStates: string[];
+  pageSize?: number;
+  fetchImpl?: FetchLike;
+  logger?: Logger;
+}
+
+interface GraphQLResponse<T> {
+  data?: T;
+  errors?: Array<{ message: string; type?: string }>;
+}
+
+interface ProjectItemsQueryData {
+  user?: { projectV2: ProjectV2Node | null } | null;
+  organization?: { projectV2: ProjectV2Node | null } | null;
+}
+
+interface ProjectV2Node {
+  items: {
+    nodes: ProjectItemNode[];
+    pageInfo: {
+      hasNextPage: boolean;
+      endCursor: string | null;
+    };
+  };
+}
+
+interface ProjectItemNode {
+  id: string;
+  content?: IssueNode | null;
+  fieldValues: {
+    nodes: Array<
+      | {
+          __typename: "ProjectV2ItemFieldSingleSelectValue";
+          name: string;
+          field?: { name: string } | null;
+        }
+      | {
+          __typename: string;
+        }
+    >;
+  };
+}
+
+interface IssueNode {
+  __typename: "Issue";
+  id: string;
+  number: number;
+  title: string;
+  body: string;
+  url: string;
+  updatedAt: string;
+  state: "OPEN" | "CLOSED";
+  labels: { nodes: Array<{ name: string }> };
+  assignees: { nodes: Array<{ login: string }> };
+}
+
+const PROJECT_ITEMS_QUERY = `
+  query ProjectItems($owner: String!, $projectNumber: Int!, $after: String, $pageSize: Int!) {
+    user(login: $owner) {
+      projectV2(number: $projectNumber) {
+        items(first: $pageSize, after: $after) {
+          nodes {
+            id
+            fieldValues(first: 20) {
+              nodes {
+                __typename
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  field {
+                    ... on ProjectV2SingleSelectField {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+            content {
+              __typename
+              ... on Issue {
+                id
+                number
+                title
+                body
+                url
+                updatedAt
+                state
+                labels(first: 20) {
+                  nodes {
+                    name
+                  }
+                }
+                assignees(first: 20) {
+                  nodes {
+                    login
+                  }
+                }
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+    organization(login: $owner) {
+      projectV2(number: $projectNumber) {
+        items(first: $pageSize, after: $after) {
+          nodes {
+            id
+            fieldValues(first: 20) {
+              nodes {
+                __typename
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  field {
+                    ... on ProjectV2SingleSelectField {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+            content {
+              __typename
+              ... on Issue {
+                id
+                number
+                title
+                body
+                url
+                updatedAt
+                state
+                labels(first: 20) {
+                  nodes {
+                    name
+                  }
+                }
+                assignees(first: 20) {
+                  nodes {
+                    login
+                  }
+                }
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+`;
+
+export class GitHubProjectsAdapter implements TrackerAdapter {
+  private readonly fetchImpl: FetchLike;
+  private readonly pageSize: number;
+  private readonly activeStates: Set<string>;
+
+  constructor(private readonly options: GitHubProjectsAdapterOptions) {
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.pageSize = options.pageSize ?? 50;
+    this.activeStates = new Set(options.activeStates.map(normalizeState));
+  }
+
   async listEligibleItems(): Promise<NormalizedWorkItem[]> {
-    return [];
+    return this.fetchEligibleItems();
+  }
+
+  async fetchEligibleItems(): Promise<NormalizedWorkItem[]> {
+    const items = await this.fetchAllProjectItems();
+    return items.filter((item) => this.activeStates.has(normalizeState(item.state)));
+  }
+
+  async fetchByIssueNumbers(issueNumbers: number[]): Promise<NormalizedWorkItem[]> {
+    if (issueNumbers.length === 0) {
+      return [];
+    }
+
+    const wanted = new Set(issueNumbers);
+    const items = await this.fetchAllProjectItems();
+    return items.filter((item) => item.number !== undefined && wanted.has(item.number));
   }
 
   async markInProgress(_itemId: string): Promise<void> {
@@ -18,4 +207,168 @@ export class GitHubProjectsAdapterPlaceholder implements TrackerAdapter {
   async markDone(_itemId: string): Promise<void> {
     throw new Error("GitHub Projects write path not implemented yet");
   }
+
+  private async fetchAllProjectItems(): Promise<NormalizedWorkItem[]> {
+    const items: NormalizedWorkItem[] = [];
+    const seen = new Set<string>();
+
+    let cursor: string | null = null;
+    let hasNextPage = true;
+    let page = 0;
+
+    while (hasNextPage) {
+      page += 1;
+      if (page > 100) {
+        throw new Error("GitHub Projects pagination exceeded safe limit (100 pages)");
+      }
+
+      const responseData: ProjectItemsQueryData = await this.query<ProjectItemsQueryData>(
+        PROJECT_ITEMS_QUERY,
+        {
+          owner: this.options.owner,
+          projectNumber: this.options.projectNumber,
+          after: cursor,
+          pageSize: this.pageSize,
+        },
+      );
+
+      const project: ProjectV2Node | null | undefined =
+        responseData.user?.projectV2 ?? responseData.organization?.projectV2;
+      if (!project) {
+        throw new Error(
+          `Project #${this.options.projectNumber} not found for owner ${this.options.owner}`,
+        );
+      }
+
+      for (const node of project.items.nodes) {
+        const normalized = mapProjectItem(node);
+        if (!normalized || seen.has(normalized.id)) {
+          continue;
+        }
+        seen.add(normalized.id);
+        items.push(normalized);
+      }
+
+      hasNextPage = project.items.pageInfo.hasNextPage;
+      cursor = project.items.pageInfo.endCursor;
+    }
+
+    this.options.logger?.info("tracker.github_projects.fetch", {
+      fetchedCount: items.length,
+      projectNumber: this.options.projectNumber,
+      owner: this.options.owner,
+    });
+
+    return items;
+  }
+
+  private async query<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+    const httpResponse: Response = await this.fetchImpl("https://api.github.com/graphql", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${this.options.token}`,
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    if (!httpResponse.ok) {
+      const bodyText = await httpResponse.text();
+      throw new Error(`GitHub GraphQL request failed (${httpResponse.status}): ${bodyText}`);
+    }
+
+    const payload = (await httpResponse.json()) as GraphQLResponse<T>;
+    if (payload.errors && payload.errors.length > 0) {
+      const message = payload.errors.map((error) => error.message).join("; ");
+      throw new Error(`GitHub GraphQL returned errors: ${message}`);
+    }
+
+    if (!payload.data) {
+      throw new Error("GitHub GraphQL returned an empty response body");
+    }
+
+    return payload.data;
+  }
+}
+
+export class GitHubProjectsAdapterPlaceholder extends GitHubProjectsAdapter {
+  constructor() {
+    super({
+      owner: "",
+      projectNumber: 0,
+      token: "",
+      activeStates: [],
+      fetchImpl: async () => {
+        throw new Error("GitHub Projects adapter placeholder is not configured");
+      },
+    });
+  }
+}
+
+function mapProjectItem(node: ProjectItemNode): NormalizedWorkItem | null {
+  if (!node.content || node.content.__typename !== "Issue") {
+    return null;
+  }
+
+  const issue = node.content;
+  const statusFromField = findProjectStatus(node);
+  const derivedState = statusFromField ?? (issue.state === "CLOSED" ? "done" : "todo");
+
+  return {
+    id: issue.id,
+    number: issue.number,
+    title: issue.title,
+    body: issue.body,
+    url: issue.url,
+    updatedAt: issue.updatedAt,
+    state: coerceWorkItemState(derivedState),
+    labels: issue.labels.nodes.map((label) => label.name),
+    assignees: issue.assignees.nodes.map((assignee) => assignee.login),
+  };
+}
+
+function findProjectStatus(node: ProjectItemNode): string | undefined {
+  for (const value of node.fieldValues.nodes) {
+    if (!isSingleSelectFieldValue(value)) {
+      continue;
+    }
+
+    const fieldName = value.field?.name?.toLowerCase();
+    if (!fieldName) {
+      continue;
+    }
+
+    if (fieldName === "status" || fieldName.includes("state")) {
+      return value.name;
+    }
+  }
+
+  return undefined;
+}
+
+function isSingleSelectFieldValue(
+  value: ProjectItemNode["fieldValues"]["nodes"][number],
+): value is Extract<
+  ProjectItemNode["fieldValues"]["nodes"][number],
+  { __typename: "ProjectV2ItemFieldSingleSelectValue" }
+> {
+  return value.__typename === "ProjectV2ItemFieldSingleSelectValue";
+}
+
+function normalizeState(state: string): string {
+  return state.trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function coerceWorkItemState(state: string): WorkItemState {
+  const normalized = normalizeState(state);
+  if (normalized === "in_progress" || normalized === "inprogress") {
+    return "in_progress";
+  }
+  if (normalized === "blocked") {
+    return "blocked";
+  }
+  if (normalized === "done" || normalized === "closed") {
+    return "done";
+  }
+  return "todo";
 }


### PR DESCRIPTION
## Summary
- implement a real GitHub Projects adapter read path using GitHub GraphQL
- add safe pagination, owner resolution (user/org), item normalization, and active-state filtering
- add reconciliation fetch by issue numbers
- add mocked adapter tests for pagination/filtering, reconciliation, and GraphQL error handling

## Issue
- Closes #6

## Quality gate
- ✅ `npm run typecheck`
- ✅ `npm run build`
- ⚠️ `npm test` fails due to pre-existing tests in `dist/model/work-item.test.js` expecting missing exports (`normalizeState`, `sanitizeWorkspaceKey`) from `src/model/work-item.ts`. This is outside Issue #6 scope and unchanged in this PR.
