### PR TITLE
feat: implement workspace manager for issue #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ npm test
 - `src/config/runtime-config.ts` - canonical runtime config type
 - `src/config/resolver.ts` - typed config getters + defaults/env resolution/validation
 - `src/logging/logger.ts` - structured JSON logger baseline
-- `src/bootstrap.ts` - loader/tracker/logger を束ねて runtime を生成する初期化ヘルパー
+- `src/bootstrap.ts` - initialization helper that wires loader/tracker/logger into runtime startup
+- `src/workspace/manager.ts` - deterministic workspace lifecycle manager with hooks and terminal-state cleanup guardrails
 
 ## Runtime behavior (current)
 
@@ -44,6 +45,14 @@ npm test
 - Runtime state is process-local and is reset on process restart.
 - After restart, the next tick reconstructs behavior from tracker eligibility and re-dispatches as needed.
 - This is acceptable for MVP/no-DB mode, but durable checkpoints will be required for stronger exactly-once guarantees.
+
+## Workspace manager behavior
+
+- Workspace directories are deterministic per item id via key sanitization (`item id -> safe slug`).
+- `ensureWorkspace` reuses the same directory across runs.
+- Lifecycle hooks are optional (`before_run`, `after_success`, `after_failure`) and run as non-shell commands with timeout guardrails.
+- Terminal-state cleanup is opt-in (`cleanup.enabled`) and guarded by allowed terminal states.
+- Cleanup always verifies the target path is inside the configured workspace root before deleting.
 
 ## Notes
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export * from "./orchestrator/runtime.js";
 export * from "./tracker/adapter.js";
 export * from "./workflow/contract.js";
 export * from "./workflow/loader.js";
+export * from "./workspace/manager.js";

--- a/src/workspace/manager.test.ts
+++ b/src/workspace/manager.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+
+import {
+  WorkspaceManager,
+  createTempWorkspaceRoot,
+  readTextFile,
+} from "./manager.js";
+import type { NormalizedWorkItem } from "../model/work-item.js";
+
+function createItem(id: string, state: NormalizedWorkItem["state"] = "todo"): NormalizedWorkItem {
+  return {
+    id,
+    title: "Item",
+    state,
+    labels: [],
+    assignees: [],
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+test("sanitizeWorkspaceKey creates deterministic safe key", () => {
+  const first = WorkspaceManager.sanitizeWorkspaceKey(" Issue #9: Workspace Manager ");
+  const second = WorkspaceManager.sanitizeWorkspaceKey("issue #9 workspace manager");
+  assert.equal(first, "issue-9-workspace-manager");
+  assert.equal(second, "issue-9-workspace-manager");
+});
+
+test("sanitizeWorkspaceKey truncates long keys with stable suffix", () => {
+  const key = WorkspaceManager.sanitizeWorkspaceKey("x".repeat(200), 24);
+  assert.equal(key.length, 24);
+  assert.match(key, /^x{15}-[0-9a-f]{8}$/);
+});
+
+test("runHook is optional and executes configured command safely", async () => {
+  const root = await createTempWorkspaceRoot();
+  const output = join(root, "item-9", "hook-output.txt");
+  const manager = new WorkspaceManager({
+    rootDir: root,
+    hooks: {
+      before_run: {
+        command: "node",
+        args: [
+          "-e",
+          "require('node:fs').writeFileSync(process.env.WORKSPACE_PATH + '/hook-output.txt', process.env.WORKSPACE_ITEM_ID)",
+        ],
+      },
+    },
+  });
+
+  const noHook = await manager.runHook("after_success", createItem("item-no-hook"));
+  assert.equal(noHook.executed, false);
+
+  const result = await manager.runHook("before_run", createItem("item-9"));
+  assert.equal(result.executed, true);
+  assert.equal(result.exitCode, 0);
+
+  const content = await readTextFile(output);
+  assert.equal(content, "item-9");
+});
+
+test("cleanupTerminalItemWorkspace is guarded by config and state", async () => {
+  const root = await createTempWorkspaceRoot();
+  const manager = new WorkspaceManager({
+    rootDir: root,
+    cleanup: {
+      enabled: true,
+      terminalStates: ["done"],
+    },
+  });
+
+  const item = createItem("item-cleanup", "todo");
+  const workspacePath = await manager.ensureWorkspace(item.id);
+
+  const skipped = await manager.cleanupTerminalItemWorkspace(item);
+  assert.equal(skipped, false);
+
+  const doneItem = { ...item, state: "done" as const };
+  const cleaned = await manager.cleanupTerminalItemWorkspace(doneItem);
+  assert.equal(cleaned, true);
+
+  await assert.rejects(readTextFile(join(workspacePath, "missing.txt")));
+});

--- a/src/workspace/manager.ts
+++ b/src/workspace/manager.ts
@@ -1,0 +1,214 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { spawn } from "node:child_process";
+
+import type { NormalizedWorkItem } from "../model/work-item.js";
+
+export type WorkspaceLifecycleHook = "before_run" | "after_success" | "after_failure";
+
+export interface HookCommand {
+  command: string;
+  args?: string[];
+  timeoutMs?: number;
+  env?: Record<string, string>;
+}
+
+export interface WorkspaceCleanupConfig {
+  enabled?: boolean;
+  terminalStates?: ReadonlyArray<NormalizedWorkItem["state"]>;
+  command?: HookCommand;
+}
+
+export interface WorkspaceManagerOptions {
+  rootDir: string;
+  maxKeyLength?: number;
+  hooks?: Partial<Record<WorkspaceLifecycleHook, HookCommand>>;
+  cleanup?: WorkspaceCleanupConfig;
+}
+
+export interface HookExecutionResult {
+  hook: WorkspaceLifecycleHook;
+  executed: boolean;
+  exitCode?: number;
+  timedOut?: boolean;
+}
+
+const DEFAULT_MAX_KEY_LENGTH = 80;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_TERMINAL_STATES: ReadonlyArray<NormalizedWorkItem["state"]> = ["done"];
+
+export class WorkspaceManager {
+  private readonly rootDir: string;
+  private readonly maxKeyLength: number;
+  private readonly hooks: Partial<Record<WorkspaceLifecycleHook, HookCommand>>;
+  private readonly cleanup: WorkspaceCleanupConfig;
+
+  constructor(options: WorkspaceManagerOptions) {
+    this.rootDir = resolve(options.rootDir);
+    this.maxKeyLength = options.maxKeyLength ?? DEFAULT_MAX_KEY_LENGTH;
+    this.hooks = options.hooks ?? {};
+    this.cleanup = options.cleanup ?? {};
+  }
+
+  static sanitizeWorkspaceKey(itemIdentifier: string, maxLength = DEFAULT_MAX_KEY_LENGTH): string {
+    const trimmed = itemIdentifier.trim().toLowerCase();
+    if (!trimmed) {
+      throw new Error("Item identifier must not be empty");
+    }
+
+    const sanitized = trimmed
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+/, "")
+      .replace(/-+$/, "")
+      .replace(/-+/g, "-");
+
+    if (!sanitized) {
+      throw new Error("Item identifier did not contain any usable characters");
+    }
+
+    if (maxLength <= 8) {
+      throw new Error("maxLength must be greater than 8");
+    }
+
+    if (sanitized.length <= maxLength) {
+      return sanitized;
+    }
+
+    const hash = createStableHashHex(sanitized).slice(0, 8);
+    return `${sanitized.slice(0, maxLength - 9)}-${hash}`;
+  }
+
+  workspacePathFor(itemIdentifier: string): string {
+    const key = WorkspaceManager.sanitizeWorkspaceKey(itemIdentifier, this.maxKeyLength);
+    return join(this.rootDir, key);
+  }
+
+  async ensureWorkspace(itemIdentifier: string): Promise<string> {
+    const workspacePath = this.workspacePathFor(itemIdentifier);
+    await mkdir(workspacePath, { recursive: true });
+    return workspacePath;
+  }
+
+  async runHook(hook: WorkspaceLifecycleHook, item: NormalizedWorkItem): Promise<HookExecutionResult> {
+    const command = this.hooks[hook];
+    if (!command) {
+      return { hook, executed: false };
+    }
+
+    const workspacePath = await this.ensureWorkspace(item.id);
+    const exit = await runCommand(command, {
+      WORKSPACE_ITEM_ID: item.id,
+      WORKSPACE_ITEM_STATE: item.state,
+      WORKSPACE_ITEM_NUMBER: String(item.number ?? ""),
+      WORKSPACE_PATH: workspacePath,
+    });
+
+    return {
+      hook,
+      executed: true,
+      exitCode: exit.exitCode,
+      timedOut: exit.timedOut,
+    };
+  }
+
+  async cleanupTerminalItemWorkspace(item: NormalizedWorkItem): Promise<boolean> {
+    if (!this.cleanup.enabled) {
+      return false;
+    }
+
+    const terminalStates = this.cleanup.terminalStates ?? DEFAULT_TERMINAL_STATES;
+    if (!terminalStates.includes(item.state)) {
+      return false;
+    }
+
+    const workspacePath = this.workspacePathFor(item.id);
+    ensurePathUnderRoot(this.rootDir, workspacePath);
+
+    if (this.cleanup.command) {
+      await runCommand(this.cleanup.command, {
+        WORKSPACE_ITEM_ID: item.id,
+        WORKSPACE_ITEM_STATE: item.state,
+        WORKSPACE_ITEM_NUMBER: String(item.number ?? ""),
+        WORKSPACE_PATH: workspacePath,
+      });
+    }
+
+    await rm(workspacePath, { recursive: true, force: true });
+    return true;
+  }
+}
+
+interface CommandResult {
+  exitCode: number;
+  timedOut: boolean;
+}
+
+async function runCommand(command: HookCommand, extraEnv: Record<string, string>): Promise<CommandResult> {
+  if (!command.command || basename(command.command) !== command.command) {
+    throw new Error("Hook command must be a bare executable name without path separators");
+  }
+
+  return await new Promise<CommandResult>((resolvePromise, reject) => {
+    const timeoutMs = command.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const child = spawn(command.command, command.args ?? [], {
+      stdio: "ignore",
+      shell: false,
+      env: {
+        PATH: process.env.PATH ?? "",
+        ...command.env,
+        ...extraEnv,
+      },
+    });
+
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, timeoutMs);
+
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolvePromise({
+        exitCode: code ?? 1,
+        timedOut,
+      });
+    });
+  });
+}
+
+function ensurePathUnderRoot(rootDir: string, candidatePath: string): void {
+  const root = resolve(rootDir);
+  const candidate = resolve(candidatePath);
+  if (candidate !== root && !candidate.startsWith(`${root}/`)) {
+    throw new Error(`Refusing to operate outside root directory: ${candidate}`);
+  }
+}
+
+function createStableHashHex(input: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+// test helpers
+export async function createTempWorkspaceRoot(prefix = "workspace-manager-"): Promise<string> {
+  return await mkdtemp(join(tmpdir(), prefix));
+}
+
+export async function readTextFile(path: string): Promise<string> {
+  return await readFile(path, "utf8");
+}
+
+export async function writeTextFile(path: string, content: string): Promise<void> {
+  await writeFile(path, content, "utf8");
+}


### PR DESCRIPTION
## Summary
- implement a deterministic `WorkspaceManager` that maps item IDs to sanitized workspace keys and stable directories
- add configurable lifecycle hooks (`before_run`, `after_success`, `after_failure`) executed with non-shell guardrails and timeout
- add guarded terminal-item cleanup with configurable terminal states and optional cleanup command
- document workspace lifecycle behavior in README and export the module from package entrypoint
- add unit tests for key sanitization, hook execution behavior, and cleanup guards

## Related issue
Closes #9

## Quality gate
- `npm run build` ✅
- `npm run typecheck` ✅
- `npm test` ⚠️ fails due to pre-existing missing implementations for issues #10-#12 (work-item normalizer/runtime retry state/tracker adapter constructor expectations).
  - New workspace manager tests pass.
