### PR TITLE
feat: implement agent runner interface and subprocess integration (#10)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from "./config/resolver.js";
 export * from "./logging/logger.js";
 export * from "./model/work-item.js";
 export * from "./orchestrator/runtime.js";
+export * from "./runner/agent-runner.js";
 export * from "./tracker/adapter.js";
 export * from "./workflow/contract.js";
 export * from "./workflow/loader.js";

--- a/src/orchestrator/runtime.ts
+++ b/src/orchestrator/runtime.ts
@@ -1,5 +1,6 @@
 import type { Logger } from "../logging/logger.js";
 import type { NormalizedWorkItem } from "../model/work-item.js";
+import type { AgentRunner, RunnerPromptTemplate } from "../runner/agent-runner.js";
 import type { TrackerAdapter } from "../tracker/adapter.js";
 import type { WorkflowContract } from "../workflow/contract.js";
 
@@ -23,6 +24,16 @@ export interface PollingRuntimeOptions {
   now?: () => number;
 }
 
+export interface RuntimeRunnerContext {
+  workspaceResolver(item: NormalizedWorkItem): string;
+  promptTemplate: RunnerPromptTemplate;
+  command: {
+    command: string;
+    args?: string[];
+    env?: NodeJS.ProcessEnv;
+  };
+}
+
 export class PollingRuntime implements OrchestratorRuntime {
   private readonly states = new Map<string, ItemRuntimeState>();
   private readonly maxRetryAttempts: number;
@@ -33,6 +44,8 @@ export class PollingRuntime implements OrchestratorRuntime {
     private readonly tracker: TrackerAdapter,
     private readonly workflow: WorkflowContract,
     private readonly logger: Logger,
+    private readonly runner?: AgentRunner,
+    private readonly runnerContext?: RuntimeRunnerContext,
     options: PollingRuntimeOptions = {},
   ) {
     this.maxRetryAttempts = options.maxRetryAttempts ?? 3;
@@ -65,6 +78,27 @@ export class PollingRuntime implements OrchestratorRuntime {
       freeSlots,
       maxConcurrency,
     });
+
+    if (!this.runner || !this.runnerContext || selected.length === 0) {
+      return;
+    }
+
+    const item = selected[0];
+    const handle = this.runner.run({
+      item,
+      workspaceDir: this.runnerContext.workspaceResolver(item),
+      promptTemplate: this.runnerContext.promptTemplate,
+      command: this.runnerContext.command,
+    });
+
+    for await (const event of handle.events) {
+      this.logger.info("runtime.runner.event", {
+        itemId: item.id,
+        eventType: event.type,
+      });
+    }
+
+    await handle.result;
   }
 
   markRunning(itemId: string): void {
@@ -98,7 +132,6 @@ export class PollingRuntime implements OrchestratorRuntime {
     this.scheduleRetry(state, reason);
   }
 
-  // test/diagnostic helper
   getItemState(itemId: string): Readonly<ItemRuntimeState> | undefined {
     const state = this.states.get(itemId);
     return state ? { ...state } : undefined;

--- a/src/runner/agent-runner.test.ts
+++ b/src/runner/agent-runner.test.ts
@@ -1,0 +1,117 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+import type { NormalizedWorkItem } from "../model/work-item.js";
+import { SubprocessAgentRunner } from "./agent-runner.js";
+
+const fixtureItem: NormalizedWorkItem = {
+  id: "item-10",
+  number: 10,
+  title: "Implement agent runner",
+  body: "Build a subprocess-backed runner",
+  state: "in_progress",
+  labels: ["enhancement"],
+  assignees: ["kouka"],
+  url: "https://example.com/issues/10",
+  updatedAt: "2026-03-06T00:00:00.000Z",
+};
+
+test("SubprocessAgentRunner.buildPrompt embeds template and work item details", () => {
+  const runner = new SubprocessAgentRunner();
+  const prompt = runner.buildPrompt(fixtureItem, {
+    system: "You are a coding agent.",
+    task: "Solve the issue in scope.",
+  });
+
+  assert.match(prompt, /You are a coding agent\./);
+  assert.match(prompt, /Solve the issue in scope\./);
+  assert.match(prompt, /Issue Number: 10/);
+  assert.match(prompt, /Title: Implement agent runner/);
+});
+
+test("SubprocessAgentRunner.run streams events and captures metrics", async () => {
+  const runner = new SubprocessAgentRunner();
+  const handle = runner.run({
+    item: fixtureItem,
+    workspaceDir: process.cwd(),
+    promptTemplate: {
+      system: "System",
+      task: "Task",
+    },
+    command: {
+      command: process.execPath,
+      args: [
+        "-e",
+        [
+          'console.log("hello from agent")',
+          'console.log("TOKENS=42")',
+        ].join(";"),
+      ],
+    },
+  });
+
+  const events = (async () => {
+    const acc: string[] = [];
+    for await (const event of handle.events) {
+      acc.push(event.type);
+    }
+    return acc;
+  })();
+
+  const result = await handle.result;
+  const emitted = await events;
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.metrics.tokenCount, 42);
+  assert.ok(result.metrics.runtimeMs >= 0);
+  assert.ok(emitted.includes("started"));
+  assert.ok(emitted.includes("stdout"));
+  assert.ok(emitted.includes("metrics"));
+  assert.ok(emitted.includes("completed"));
+});
+
+test("SubprocessAgentRunner.run surfaces non-zero exits with actionable details", async () => {
+  const runner = new SubprocessAgentRunner();
+  const handle = runner.run({
+    item: fixtureItem,
+    workspaceDir: process.cwd(),
+    promptTemplate: {
+      system: "System",
+      task: "Task",
+    },
+    command: {
+      command: process.execPath,
+      args: ["-e", 'console.error("boom"); process.exit(2);'],
+    },
+  });
+
+  await assert.rejects(handle.result, (error: Error & { details?: { exitCode?: number; stderrTail?: string } }) => {
+    assert.equal(error.name, "AgentRunError");
+    assert.equal(error.details?.exitCode, 2);
+    assert.match(error.details?.stderrTail ?? "", /boom/);
+    return true;
+  });
+});
+
+test("SubprocessAgentRunner supports cancellation", async () => {
+  const runner = new SubprocessAgentRunner();
+  const handle = runner.run({
+    item: fixtureItem,
+    workspaceDir: process.cwd(),
+    promptTemplate: {
+      system: "System",
+      task: "Task",
+    },
+    command: {
+      command: process.execPath,
+      args: ["-e", 'setInterval(() => console.log("running"), 100);'],
+    },
+  });
+
+  handle.cancel();
+
+  await assert.rejects(handle.result, (error: Error & { details?: { signal?: NodeJS.Signals | null } }) => {
+    assert.equal(error.name, "AgentRunError");
+    assert.ok(error.details?.signal === "SIGINT" || error.details?.signal === "SIGTERM");
+    return true;
+  });
+});

--- a/src/runner/agent-runner.ts
+++ b/src/runner/agent-runner.ts
@@ -1,0 +1,284 @@
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import type { Readable } from "node:stream";
+import { createInterface } from "node:readline";
+import type { NormalizedWorkItem } from "../model/work-item.js";
+
+export interface RunnerPromptTemplate {
+  system: string;
+  task: string;
+}
+
+export interface AgentRunnerCommand {
+  command: string;
+  args?: string[];
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface AgentRunRequest {
+  item: NormalizedWorkItem;
+  workspaceDir: string;
+  promptTemplate: RunnerPromptTemplate;
+  command: AgentRunnerCommand;
+}
+
+export interface AgentRunMetrics {
+  runtimeMs: number;
+  tokenCount?: number;
+}
+
+export interface AgentRunResult {
+  exitCode: number;
+  signal: NodeJS.Signals | null;
+  metrics: AgentRunMetrics;
+}
+
+export type AgentRunnerEvent =
+  | { type: "started"; pid: number; prompt: string }
+  | { type: "stdout"; line: string }
+  | { type: "stderr"; line: string }
+  | { type: "metrics"; tokenCount: number }
+  | { type: "terminated"; reason: "cancel" | "terminate" }
+  | { type: "completed"; result: AgentRunResult }
+  | { type: "failed"; error: AgentRunError };
+
+export interface AgentRunHandle {
+  events: AsyncIterable<AgentRunnerEvent>;
+  result: Promise<AgentRunResult>;
+  cancel(): void;
+  terminate(): void;
+}
+
+export interface AgentRunner {
+  buildPrompt(item: NormalizedWorkItem, promptTemplate: RunnerPromptTemplate): string;
+  run(request: AgentRunRequest): AgentRunHandle;
+}
+
+export class AgentRunError extends Error {
+  constructor(
+    message: string,
+    readonly details: {
+      code?: string;
+      command: string;
+      args: string[];
+      workspaceDir: string;
+      stderrTail?: string;
+      exitCode?: number;
+      signal?: NodeJS.Signals | null;
+    },
+  ) {
+    super(message);
+    this.name = "AgentRunError";
+  }
+}
+
+class AsyncEventQueue<T> implements AsyncIterable<T> {
+  private readonly values: T[] = [];
+  private readonly waiters: Array<(result: IteratorResult<T>) => void> = [];
+  private closed = false;
+
+  push(value: T): void {
+    if (this.closed) return;
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter({ done: false, value });
+      return;
+    }
+    this.values.push(value);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    while (this.waiters.length > 0) {
+      const waiter = this.waiters.shift();
+      waiter?.({ done: true, value: undefined as never });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: () => {
+        if (this.values.length > 0) {
+          return Promise.resolve({ done: false, value: this.values.shift() as T });
+        }
+        if (this.closed) {
+          return Promise.resolve({ done: true, value: undefined as never });
+        }
+        return new Promise<IteratorResult<T>>((resolve) => {
+          this.waiters.push(resolve);
+        });
+      },
+    };
+  }
+}
+
+export class SubprocessAgentRunner implements AgentRunner {
+  buildPrompt(item: NormalizedWorkItem, promptTemplate: RunnerPromptTemplate): string {
+    const labels = item.labels.length > 0 ? item.labels.join(", ") : "none";
+    const assignees = item.assignees.length > 0 ? item.assignees.join(", ") : "none";
+    const details = [
+      `Item ID: ${item.id}`,
+      `Issue Number: ${item.number ?? "n/a"}`,
+      `Title: ${item.title}`,
+      `State: ${item.state}`,
+      `Labels: ${labels}`,
+      `Assignees: ${assignees}`,
+      `Updated At: ${item.updatedAt}`,
+      `URL: ${item.url ?? "n/a"}`,
+      "",
+      "Body:",
+      item.body ?? "(empty)",
+    ].join("\n");
+
+    return [promptTemplate.system.trim(), "", promptTemplate.task.trim(), "", details].join("\n");
+  }
+
+  run(request: AgentRunRequest): AgentRunHandle {
+    const prompt = this.buildPrompt(request.item, request.promptTemplate);
+    const queue = new AsyncEventQueue<AgentRunnerEvent>();
+    const startAt = Date.now();
+    const args = [...(request.command.args ?? []), prompt];
+    let stderrTail = "";
+    let tokenCount: number | undefined;
+
+    const child = spawn(request.command.command, args, {
+      cwd: request.workspaceDir,
+      env: {
+        ...process.env,
+        ...request.command.env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    if (!child.pid) {
+      const error = new AgentRunError("Failed to spawn agent process", {
+        command: request.command.command,
+        args,
+        workspaceDir: request.workspaceDir,
+      });
+      queue.push({ type: "failed", error });
+      queue.close();
+      return {
+        events: queue,
+        result: Promise.reject(error),
+        cancel: () => undefined,
+        terminate: () => undefined,
+      };
+    }
+
+    queue.push({ type: "started", pid: child.pid, prompt });
+
+    this.streamLines(child, "stdout", (line) => {
+      queue.push({ type: "stdout", line });
+      const parsed = this.parseMetricLine(line);
+      if (parsed !== undefined) {
+        tokenCount = parsed;
+        queue.push({ type: "metrics", tokenCount: parsed });
+      }
+    });
+
+    this.streamLines(child, "stderr", (line) => {
+      stderrTail = [stderrTail, line].filter(Boolean).join("\n").slice(-2000);
+      queue.push({ type: "stderr", line });
+    });
+
+    const finalize = (result: AgentRunResult): AgentRunResult => {
+      queue.push({ type: "completed", result });
+      queue.close();
+      return result;
+    };
+
+    const result = new Promise<AgentRunResult>((resolve, reject) => {
+      child.once("error", (err) => {
+        const error = new AgentRunError("Agent process errored", {
+          code: (err as NodeJS.ErrnoException).code,
+          command: request.command.command,
+          args,
+          workspaceDir: request.workspaceDir,
+          stderrTail,
+        });
+        queue.push({ type: "failed", error });
+        queue.close();
+        reject(error);
+      });
+
+      child.once("close", (exitCode, signal) => {
+        const runtimeMs = Date.now() - startAt;
+        const settled = {
+          exitCode: exitCode ?? 1,
+          signal,
+          metrics: {
+            runtimeMs,
+            tokenCount,
+          },
+        } satisfies AgentRunResult;
+
+        if ((exitCode ?? 1) !== 0) {
+          const error = new AgentRunError("Agent process exited with non-zero status", {
+            command: request.command.command,
+            args,
+            workspaceDir: request.workspaceDir,
+            stderrTail,
+            exitCode: settled.exitCode,
+            signal,
+          });
+          queue.push({ type: "failed", error });
+          queue.close();
+          reject(error);
+          return;
+        }
+
+        resolve(finalize(settled));
+      });
+    });
+
+    return {
+      events: queue,
+      result,
+      cancel: () => this.kill(child, "SIGINT", queue, "cancel"),
+      terminate: () => this.kill(child, "SIGTERM", queue, "terminate"),
+    };
+  }
+
+  private streamLines(
+    child: ChildProcessByStdio<null, Readable, Readable>,
+    stream: "stdout" | "stderr",
+    onLine: (line: string) => void,
+  ): void {
+    const rl = createInterface({ input: child[stream] });
+    rl.on("line", onLine);
+    child.once("close", () => {
+      rl.close();
+    });
+  }
+
+  private kill(
+    child: ChildProcessByStdio<null, Readable, Readable>,
+    signal: NodeJS.Signals,
+    queue: AsyncEventQueue<AgentRunnerEvent>,
+    reason: "cancel" | "terminate",
+  ): void {
+    if (child.killed) return;
+    child.kill(signal);
+    queue.push({ type: "terminated", reason });
+  }
+
+  private parseMetricLine(line: string): number | undefined {
+    const prefixed = line.match(/^TOKENS=(\d+)$/);
+    if (prefixed) {
+      return Number(prefixed[1]);
+    }
+
+    try {
+      const parsed = JSON.parse(line) as { tokenCount?: unknown; tokens?: unknown };
+      const candidate = parsed.tokenCount ?? parsed.tokens;
+      if (typeof candidate === "number" && Number.isFinite(candidate)) {
+        return candidate;
+      }
+    } catch {
+      // Not JSON line; ignore.
+    }
+
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- add a typed `AgentRunner` execution layer with a subprocess-backed implementation
- build deterministic agent prompts from workflow templates and normalized work items
- stream typed runtime events (`started`, `stdout`, `stderr`, `metrics`, `terminated`, `completed`, `failed`) and expose cancellation/termination controls
- wire optional runner execution into `PollingRuntime` so orchestrator can consume runner events
- add unit tests for prompt construction, event streaming + metrics capture, failure surfacing, and cancellation behavior

## Validation
- `rm -rf dist && npm run build && npm run test`

Closes #10
