### PR TITLE
docs: replace remaining Japanese text with English

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm test
 - `src/config/runtime-config.ts` - canonical runtime config type
 - `src/config/resolver.ts` - typed config getters + defaults/env resolution/validation
 - `src/logging/logger.ts` - structured JSON logger baseline
-- `src/bootstrap.ts` - loader/tracker/logger を束ねて runtime を生成する初期化ヘルパー
+- `src/bootstrap.ts` - initialization helper that wires loader/tracker/logger and constructs the runtime
 
 ## Notes
 

--- a/docs/workflow-schema.md
+++ b/docs/workflow-schema.md
@@ -1,6 +1,6 @@
 # WORKFLOW.md schema (GitHub Projects)
 
-このドキュメントは `WORKFLOW.md` の front matter 契約を定義する。
+This document defines the `WORKFLOW.md` front matter contract.
 
 ## Top-level keys
 
@@ -46,11 +46,11 @@ hooks:
 
 - `GITHUB_TOKEN` (or any variable name set in `tokenEnv`)
 
-`tokenEnv` に設定された環境変数は、実行環境で必ず解決できる必要がある。
+The environment variable configured in `tokenEnv` must always be resolvable in the runtime environment.
 
 ## Validation expectations (explicit + testable)
 
-`validateWorkflowContract` は以下のエラーコードを返す:
+`validateWorkflowContract` returns the following error codes:
 
 - `tracker.kind.required`
 - `tracker.kind.unsupported`
@@ -61,4 +61,4 @@ hooks:
 - `workspace.baseDir.required`
 - `agent.command.required`
 
-バリデーションは失敗を集約し、最初の1件で止めずに全エラーを返す。
+Validation aggregates failures and returns all errors instead of stopping at the first one.


### PR DESCRIPTION
## Summary\n- replace Japanese text that remained in README and workflow schema docs\n- keep wording aligned with existing English documentation style\n\n## Verification\n- scanned repository text for Japanese characters after edits\n- result: no Japanese characters found