### PR TITLE
feat: replace hand-rolled YAML parser with yaml package (#27)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "symphony-github-projects",
       "version": "0.1.0",
+      "dependencies": {
+        "yaml": "^2.8.2"
+      },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@types/node": "^22.19.15",
@@ -1490,6 +1493,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "prettier": "^3.5.3",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.26.1"
+  },
+  "dependencies": {
+    "yaml": "^2.8.2"
   }
 }

--- a/src/workflow/loader.test.ts
+++ b/src/workflow/loader.test.ts
@@ -1,49 +1,76 @@
-import test from "node:test";
-import assert from "node:assert/strict";
-import { mkdtemp, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   WorkflowParseError,
   WorkflowValidationError,
   loadWorkflowFile,
   parseWorkflowMarkdown,
-} from "./loader.js";
+} from './loader.js';
 
-test("parses front matter and trims prompt body", () => {
+test('parses front matter and trims prompt body', () => {
   const doc = parseWorkflowMarkdown(`---\nname: demo\ncount: 3\n---\n\n  hello prompt\n\n`);
 
-  assert.deepEqual(doc.config, { name: "demo", count: 3 });
-  assert.equal(doc.prompt_template, "hello prompt");
+  assert.deepEqual(doc.config, { name: 'demo', count: 3 });
+  assert.equal(doc.prompt_template, 'hello prompt');
 });
 
-test("returns empty config when front matter is absent", () => {
-  const doc = parseWorkflowMarkdown("\n\njust prompt\n\n");
+test('parses nested front matter objects', () => {
+  const doc = parseWorkflowMarkdown(
+    `---\ntracker:\n  kind: github_projects\n  github:\n    owner: kouka-t0yohei\n    projectNumber: 1\n---\nrun\n`,
+  );
+
+  assert.deepEqual(doc.config, {
+    tracker: {
+      kind: 'github_projects',
+      github: {
+        owner: 'kouka-t0yohei',
+        projectNumber: 1,
+      },
+    },
+  });
+});
+
+test('preserves multi-line string values', () => {
+  const doc = parseWorkflowMarkdown(
+    `---\nhooks:\n  after_create: |\n    echo first\n    echo second\n---\nrun\n`,
+  );
+
+  assert.deepEqual(doc.config, {
+    hooks: {
+      after_create: 'echo first\necho second\n',
+    },
+  });
+});
+
+test('returns empty config when front matter is absent', () => {
+  const doc = parseWorkflowMarkdown('\n\njust prompt\n\n');
 
   assert.deepEqual(doc.config, {});
-  assert.equal(doc.prompt_template, "just prompt");
+  assert.equal(doc.prompt_template, 'just prompt');
 });
 
-test("throws WorkflowParseError when front matter is malformed", () => {
+test('throws WorkflowParseError when front matter is malformed', () => {
   assert.throws(
-    () => parseWorkflowMarkdown("---\nname: demo\nbody without closer"),
+    () => parseWorkflowMarkdown('---\nname: demo\nbody without closer'),
     WorkflowParseError,
   );
 });
 
-test("throws WorkflowValidationError when front matter is not an object", () => {
-  assert.throws(
-    () => parseWorkflowMarkdown("---\n- item\n---\ntext"),
-    WorkflowValidationError,
-  );
+test('throws WorkflowValidationError when front matter is not an object', () => {
+  assert.throws(() => parseWorkflowMarkdown('---\n- item\n---\ntext'), WorkflowValidationError);
+
+  assert.throws(() => parseWorkflowMarkdown('---\ntrue\n---\ntext'), WorkflowValidationError);
 });
 
-test("loadWorkflowFile reads explicit path", async () => {
-  const dir = await mkdtemp(join(tmpdir(), "workflow-loader-"));
-  const filePath = join(dir, "WORKFLOW.md");
-  await writeFile(filePath, "---\nname: from-file\n---\n\nbody\n", "utf8");
+test('loadWorkflowFile reads explicit path', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'workflow-loader-'));
+  const filePath = join(dir, 'WORKFLOW.md');
+  await writeFile(filePath, '---\nname: from-file\n---\n\nbody\n', 'utf8');
 
   const doc = await loadWorkflowFile(filePath);
-  assert.deepEqual(doc.config, { name: "from-file" });
-  assert.equal(doc.prompt_template, "body");
+  assert.deepEqual(doc.config, { name: 'from-file' });
+  assert.equal(doc.prompt_template, 'body');
 });

--- a/src/workflow/loader.ts
+++ b/src/workflow/loader.ts
@@ -1,5 +1,6 @@
-import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import YAML from 'yaml';
 
 export type WorkflowConfig = Record<string, unknown>;
 
@@ -11,30 +12,30 @@ export interface WorkflowDocument {
 export class WorkflowLoadError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {
     super(message, options);
-    this.name = "WorkflowLoadError";
+    this.name = 'WorkflowLoadError';
   }
 }
 
 export class WorkflowParseError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "WorkflowParseError";
+    this.name = 'WorkflowParseError';
   }
 }
 
 export class WorkflowValidationError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "WorkflowValidationError";
+    this.name = 'WorkflowValidationError';
   }
 }
 
 export async function loadWorkflowFile(path?: string): Promise<WorkflowDocument> {
-  const workflowPath = path ? resolve(path) : resolve(process.cwd(), "WORKFLOW.md");
+  const workflowPath = path ? resolve(path) : resolve(process.cwd(), 'WORKFLOW.md');
 
   let raw: string;
   try {
-    raw = await readFile(workflowPath, "utf8");
+    raw = await readFile(workflowPath, 'utf8');
   } catch (error) {
     throw new WorkflowLoadError(`Failed to read WORKFLOW.md: ${workflowPath}`, { cause: error });
   }
@@ -43,18 +44,18 @@ export async function loadWorkflowFile(path?: string): Promise<WorkflowDocument>
 }
 
 export function parseWorkflowMarkdown(input: string): WorkflowDocument {
-  const normalized = input.replace(/\r\n/g, "\n");
+  const normalized = input.replace(/\r\n/g, '\n');
 
-  if (!normalized.startsWith("---\n")) {
+  if (!normalized.startsWith('---\n')) {
     return {
       config: {},
       prompt_template: normalized.trim(),
     };
   }
 
-  const closingIndex = normalized.indexOf("\n---\n", 4);
+  const closingIndex = normalized.indexOf('\n---\n', 4);
   if (closingIndex < 0) {
-    throw new WorkflowParseError("Malformed front matter: missing closing delimiter");
+    throw new WorkflowParseError('Malformed front matter: missing closing delimiter');
   }
 
   const frontMatterText = normalized.slice(4, closingIndex).trim();
@@ -72,41 +73,22 @@ function parseYamlObject(text: string): WorkflowConfig {
     return {};
   }
 
-  const result: WorkflowConfig = {};
-
-  for (const line of text.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) {
-      continue;
-    }
-
-    if (trimmed.startsWith("-") || trimmed.startsWith("[") || trimmed.startsWith("{")) {
-      throw new WorkflowValidationError("Front matter must be a YAML object");
-    }
-
-    const match = trimmed.match(/^([A-Za-z0-9_-]+)\s*:\s*(.*)$/);
-    if (!match) {
-      throw new WorkflowParseError(`Malformed front matter line: ${line}`);
-    }
-
-    const [, key, rawValue] = match;
-    result[key] = parseScalar(rawValue);
+  let parsed: unknown;
+  try {
+    parsed = YAML.parse(text);
+  } catch (error) {
+    throw new WorkflowParseError(
+      `Malformed front matter: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 
-  return result;
+  if (!isPlainObject(parsed)) {
+    throw new WorkflowValidationError('Front matter must be a YAML object');
+  }
+
+  return parsed;
 }
 
-function parseScalar(value: string): unknown {
-  const v = value.trim();
-
-  if (v === "") return "";
-  if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
-    return v.slice(1, -1);
-  }
-  if (v === "true") return true;
-  if (v === "false") return false;
-  if (v === "null") return null;
-  if (/^-?\d+(\.\d+)?$/.test(v)) return Number(v);
-
-  return v;
+function isPlainObject(value: unknown): value is WorkflowConfig {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
## Summary
- add `yaml` as a runtime dependency
- replace hand-rolled front matter parsing with `YAML.parse()`
- validate that front matter parses to a plain object and raise validation error otherwise
- add tests for nested config parsing, multi-line hook strings, and non-object YAML front matter

## Validation
- `npm run format && npm run lint` ✅
- `npm run build && npm test` ⚠️ one pre-existing failure in `runtime.test.ts` (unchanged by this PR)

Closes #27
