### PR TITLE
feat: add Liquid-compatible prompt rendering (#34)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "symphony-github-projects",
       "version": "0.1.0",
       "dependencies": {
+        "liquidjs": "^10.24.0",
         "yaml": "^2.8.2"
       },
       "devDependencies": {
@@ -652,6 +653,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1115,6 +1125,26 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/liquidjs": {
+      "version": "10.24.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.24.0.tgz",
+      "integrity": "sha512-TAUNAdgwaAXjjcUFuYVJm9kOVH7zc0mTKxsG9t9Lu4qdWjB2BEblyVIYpjWcmJLMGgiYqnGNJjpNMHx0gp/46A==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
       }
     },
     "node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typescript-eslint": "^8.26.1"
   },
   "dependencies": {
+    "liquidjs": "^10.24.0",
     "yaml": "^2.8.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from './logging/logger.js';
 export * from './model/work-item.js';
 export * from './orchestrator/runtime.js';
 export * from './tracker/adapter.js';
+export * from './prompt/template.js';
 
 export {
   NotImplementedWorkflowLoader,

--- a/src/prompt/template.test.ts
+++ b/src/prompt/template.test.ts
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { NormalizedWorkItem } from '../model/work-item.js';
+import { renderPromptTemplate } from './template.js';
+
+const issue: NormalizedWorkItem = {
+  id: 'ISSUE-123',
+  number: 123,
+  title: 'Fix template rendering',
+  body: 'Use strict mode',
+  state: 'todo',
+  labels: ['enhancement'],
+  assignees: ['kouka'],
+  url: 'https://example.com/issues/123',
+  updatedAt: '2026-03-06T00:00:00Z',
+};
+
+test('renderPromptTemplate renders issue and attempt variables', async () => {
+  const rendered = await renderPromptTemplate('Issue {{ issue.id }} / Attempt {{ attempt }}', {
+    issue,
+    attempt: 2,
+  });
+
+  assert.equal(rendered, 'Issue ISSUE-123 / Attempt 2');
+});
+
+test('renderPromptTemplate throws when unknown variable is referenced', async () => {
+  await assert.rejects(
+    () =>
+      renderPromptTemplate('Issue {{ issue.identifier }}', {
+        issue,
+        attempt: null,
+      }),
+    /undefined variable: issue\.identifier/,
+  );
+});
+
+test('renderPromptTemplate throws when unknown filter is referenced', async () => {
+  await assert.rejects(
+    () =>
+      renderPromptTemplate('{{ issue.id | non_existing_filter }}', {
+        issue,
+        attempt: null,
+      }),
+    /undefined filter: non_existing_filter/,
+  );
+});
+
+test('renderPromptTemplate uses default template when prompt body is empty', async () => {
+  const rendered = await renderPromptTemplate('   ', {
+    issue,
+    attempt: null,
+  });
+
+  assert.match(rendered, /You are executing automation for ISSUE-123\./);
+  assert.match(rendered, /Title: Fix template rendering/);
+  assert.match(rendered, /Attempt:\s*$/m);
+});

--- a/src/prompt/template.ts
+++ b/src/prompt/template.ts
@@ -1,0 +1,32 @@
+import { Liquid } from 'liquidjs';
+
+import type { NormalizedWorkItem } from '../model/work-item.js';
+
+const DEFAULT_PROMPT_TEMPLATE = [
+  'You are executing automation for {{ issue.id }}.',
+  'Title: {{ issue.title }}',
+  '{% if issue.body %}Body:\n{{ issue.body }}{% endif %}',
+  'Attempt: {{ attempt }}',
+].join('\n');
+
+const engine = new Liquid({
+  strictVariables: true,
+  strictFilters: true,
+});
+
+export interface PromptRenderContext {
+  issue: NormalizedWorkItem;
+  attempt: number | null;
+}
+
+export function getDefaultPromptTemplate(): string {
+  return DEFAULT_PROMPT_TEMPLATE;
+}
+
+export async function renderPromptTemplate(
+  templateBody: string,
+  context: PromptRenderContext,
+): Promise<string> {
+  const template = templateBody.trim() === '' ? DEFAULT_PROMPT_TEMPLATE : templateBody;
+  return engine.parseAndRender(template, context);
+}


### PR DESCRIPTION
Closes #34

## Changes
- Add `liquidjs` dependency for Liquid-compatible prompt rendering
- Implement `renderPromptTemplate` with `issue` and `attempt` template variables
- Enable strict mode: unknown variables and unknown filters raise errors
- Add minimal default prompt fallback when prompt body is empty
- Add tests: variable substitution, unknown variable error, unknown filter error, empty body fallback

## Testing
- `npm run lint` ✅
- `npm run build` ✅
- `npm test` — all new tests pass (18/18)