### PR TITLE
feat: implement Codex app-server stdio integration (#30)

### DIFF
--- a/src/agent/codex-app-server.test.ts
+++ b/src/agent/codex-app-server.test.ts
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+
+import { CodexAppServerClient } from './codex-app-server.js';
+
+class FakeChildProcess extends EventEmitter {
+  public readonly stdout = new EventEmitter();
+  public readonly stderr = new EventEmitter();
+  public readonly writes: string[] = [];
+  public killed = false;
+
+  public readonly stdin = {
+    write: (chunk: string): boolean => {
+      this.writes.push(chunk);
+      return true;
+    },
+    end: (): void => {
+      // no-op for tests
+    },
+  };
+
+  kill(): boolean {
+    this.killed = true;
+    return true;
+  }
+
+  emitStdoutJson(payload: unknown): void {
+    this.stdout.emit('data', `${JSON.stringify(payload)}\n`);
+  }
+
+  emitStderr(text: string): void {
+    this.stderr.emit('data', text);
+  }
+}
+
+test('spawns codex app-server with workspace cwd and sends thread/turn start', async () => {
+  const fake = new FakeChildProcess();
+  const spawnCalls: Array<{ command: string; args: string[]; cwd: string }> = [];
+
+  const client = new CodexAppServerClient({
+    cwd: '/tmp/workspace',
+    readTimeoutMs: 10,
+    stallTimeoutMs: 500,
+    spawn: (command, args, options) => {
+      spawnCalls.push({ command, args, cwd: options.cwd });
+      queueMicrotask(() => {
+        fake.emitStdoutJson({
+          params: {
+            session_id: 's1',
+            thread_id: 't1',
+            turn_id: 'turn-1',
+            usage: { input_tokens: 10, output_tokens: 3, total_tokens: 13 },
+            turn: { completed: true, active_issue: false },
+          },
+        });
+      });
+      return fake;
+    },
+  });
+
+  const result = await client.run({ renderedPrompt: 'hello codex' });
+
+  assert.equal(spawnCalls.length, 1);
+  assert.deepEqual(spawnCalls[0], {
+    command: 'codex',
+    args: ['app-server'],
+    cwd: '/tmp/workspace',
+  });
+
+  assert.equal(result.status, 'completed');
+  assert.equal(result.activeIssue, false);
+  assert.equal(result.state.sessionId, 's1');
+  assert.equal(result.state.threadId, 't1');
+  assert.equal(result.state.turnId, 'turn-1');
+  assert.equal(result.state.usage.totalTokens, 13);
+
+  const payload = fake.writes.join('');
+  assert.match(payload, /"method":"thread.start"/);
+  assert.match(payload, /"method":"turn.start"/);
+  assert.match(payload, /"message":"hello codex"/);
+});
+
+test('continues multi-turn when active issue is returned', async () => {
+  const fake = new FakeChildProcess();
+  let firstTurnEventSent = false;
+  let secondTurnEventSent = false;
+
+  const client = new CodexAppServerClient({
+    cwd: '/tmp/workspace',
+    maxTurns: 3,
+    readTimeoutMs: 10,
+    stallTimeoutMs: 500,
+    spawn: () => {
+      const timer = setInterval(() => {
+        const payload = fake.writes.join('');
+        if (!firstTurnEventSent && payload.includes('"turn":1')) {
+          firstTurnEventSent = true;
+          fake.emitStdoutJson({ params: { turn: { completed: true, active_issue: true } } });
+        }
+        if (!secondTurnEventSent && payload.includes('"turn":2')) {
+          secondTurnEventSent = true;
+          fake.emitStdoutJson({ params: { turn: { completed: true, active_issue: false } } });
+          clearInterval(timer);
+        }
+      }, 1);
+      return fake;
+    },
+  });
+
+  const result = await client.run({
+    renderedPrompt: 'first prompt',
+    continuationGuidance: 'continue please',
+  });
+
+  assert.equal(result.status, 'completed');
+  assert.equal(result.activeIssue, false);
+  assert.ok(result.state.turnsStarted >= 2);
+  assert.ok(result.state.turnsCompleted >= 2);
+
+  const payload = fake.writes.join('');
+  assert.match(payload, /"message":"first prompt"/);
+  assert.match(payload, /"message":"continue please"/);
+  assert.equal(firstTurnEventSent, true);
+  assert.equal(secondTurnEventSent, true);
+});
+
+test('detects stall and terminates the subprocess', async () => {
+  const fake = new FakeChildProcess();
+  const client = new CodexAppServerClient({
+    cwd: '/tmp/workspace',
+    readTimeoutMs: 5,
+    stallTimeoutMs: 20,
+    turnTimeoutMs: 500,
+    spawn: () => fake,
+  });
+
+  const result = await client.run({ renderedPrompt: 'will stall' });
+
+  assert.equal(result.status, 'stalled');
+  assert.equal(fake.killed, true);
+});
+
+test('classifies rate limit errors from stderr', async () => {
+  const fake = new FakeChildProcess();
+  const client = new CodexAppServerClient({
+    cwd: '/tmp/workspace',
+    readTimeoutMs: 5,
+    stallTimeoutMs: 1000,
+    turnTimeoutMs: 1000,
+    spawn: () => {
+      queueMicrotask(() => {
+        fake.emitStderr('Rate limit exceeded');
+      });
+      return fake;
+    },
+  });
+
+  const result = await client.run({ renderedPrompt: 'hello' });
+
+  assert.equal(result.status, 'rate_limited');
+  assert.match(result.errorMessage ?? '', /rate limit/i);
+});

--- a/src/agent/codex-app-server.ts
+++ b/src/agent/codex-app-server.ts
@@ -1,0 +1,397 @@
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+import { spawn as nodeSpawn } from 'node:child_process';
+
+export interface CodexUsageCounters {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+export interface CodexSessionState {
+  sessionId?: string;
+  threadId?: string;
+  turnId?: string;
+  turnsStarted: number;
+  turnsCompleted: number;
+  usage: CodexUsageCounters;
+}
+
+export interface CodexTurnResult {
+  status: 'completed' | 'error' | 'rate_limited' | 'timeout' | 'stalled';
+  activeIssue: boolean;
+  state: CodexSessionState;
+  errorMessage?: string;
+}
+
+export interface RunTurnParams {
+  renderedPrompt: string;
+  continuationGuidance?: string;
+}
+
+export interface CodexAppServerClientOptions {
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  command?: string;
+  args?: string[];
+  maxTurns?: number;
+  turnTimeoutMs?: number;
+  readTimeoutMs?: number;
+  stallTimeoutMs?: number;
+  spawn?: SpawnLike;
+}
+
+interface JsonRpcEvent {
+  [key: string]: unknown;
+}
+
+interface ChildProcessLike extends EventEmitter {
+  stdin: {
+    write(chunk: string | Buffer): boolean;
+    end(): void;
+  } | null;
+  stdout: EventEmitter | null;
+  stderr: EventEmitter | null;
+  kill(signal?: NodeJS.Signals | number): boolean;
+}
+
+type SpawnLike = (
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    stdio: ['pipe', 'pipe', 'pipe'];
+  },
+) => ChildProcessLike;
+
+const DEFAULT_MAX_TURNS = 3;
+const DEFAULT_TURN_TIMEOUT_MS = 120_000;
+const DEFAULT_READ_TIMEOUT_MS = 10_000;
+const DEFAULT_STALL_TIMEOUT_MS = 30_000;
+
+export class CodexAppServerClient {
+  private readonly state: CodexSessionState = {
+    sessionId: undefined,
+    threadId: undefined,
+    turnId: undefined,
+    turnsStarted: 0,
+    turnsCompleted: 0,
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    },
+  };
+
+  private readonly maxTurns: number;
+  private readonly turnTimeoutMs: number;
+  private readonly readTimeoutMs: number;
+  private readonly stallTimeoutMs: number;
+  private readonly command: string;
+  private readonly args: string[];
+  private readonly spawnProc: SpawnLike;
+
+  constructor(private readonly options: CodexAppServerClientOptions) {
+    this.maxTurns = options.maxTurns ?? DEFAULT_MAX_TURNS;
+    this.turnTimeoutMs = options.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS;
+    this.readTimeoutMs = options.readTimeoutMs ?? DEFAULT_READ_TIMEOUT_MS;
+    this.stallTimeoutMs = options.stallTimeoutMs ?? DEFAULT_STALL_TIMEOUT_MS;
+    this.command = options.command ?? 'codex';
+    this.args = options.args ?? ['app-server'];
+    this.spawnProc =
+      options.spawn ??
+      ((command, args, spawnOptions) =>
+        nodeSpawn(
+          command,
+          args,
+          spawnOptions as unknown as Parameters<typeof nodeSpawn>[2],
+        ) as ChildProcess);
+  }
+
+  async run(params: RunTurnParams): Promise<CodexTurnResult> {
+    const child = this.spawnProc(this.command, this.args, {
+      cwd: this.options.cwd,
+      env: {
+        ...process.env,
+        ...(this.options.env ?? {}),
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let lineBuffer = '';
+    let latestEventAt = Date.now();
+    let completed = false;
+    let activeIssue = false;
+    let errorMessage: string | undefined;
+
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      latestEventAt = Date.now();
+      lineBuffer += chunk.toString();
+      let idx = lineBuffer.indexOf('\n');
+      while (idx >= 0) {
+        const line = lineBuffer.slice(0, idx).trim();
+        lineBuffer = lineBuffer.slice(idx + 1);
+        if (line !== '') {
+          this.handleEventLine(line, (event) => {
+            this.applyEvent(event);
+            const completedFlag = readBoolean(event, [
+              'params.turn.completed',
+              'params.completed',
+              'turn.completed',
+              'completed',
+            ]);
+            if (completedFlag) {
+              completed = true;
+              this.state.turnsCompleted += 1;
+            }
+            const activeIssueFlag = readBoolean(event, [
+              'params.turn.active_issue',
+              'params.active_issue',
+              'turn.active_issue',
+              'active_issue',
+            ]);
+            if (activeIssueFlag !== undefined) {
+              activeIssue = activeIssueFlag;
+            }
+            const rateLimited = readBoolean(event, [
+              'params.rate_limited',
+              'rate_limited',
+              'error.rate_limited',
+            ]);
+            if (rateLimited) {
+              errorMessage =
+                readString(event, ['params.error.message', 'error.message']) ?? 'rate limited';
+            }
+            const eventError = readString(event, ['params.error.message', 'error.message']);
+            if (eventError) {
+              errorMessage = eventError;
+            }
+          });
+        }
+        idx = lineBuffer.indexOf('\n');
+      }
+    });
+
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      const text = chunk.toString().trim();
+      if (text !== '') {
+        errorMessage = text;
+      }
+    });
+
+    if (!child.stdin) {
+      throw new Error('codex app-server stdin is not available');
+    }
+
+    const threadStartMessage = JSON.stringify({
+      method: 'thread.start',
+      params: {
+        prompt: params.renderedPrompt,
+      },
+    });
+    child.stdin.write(`${threadStartMessage}\n`);
+
+    for (let turn = 1; turn <= this.maxTurns; turn += 1) {
+      const message =
+        turn === 1
+          ? params.renderedPrompt
+          : (params.continuationGuidance ?? 'Continue from the active issue and finish the task.');
+
+      const turnStartMessage = JSON.stringify({
+        method: 'turn.start',
+        params: {
+          message,
+          turn,
+        },
+      });
+      this.state.turnsStarted += 1;
+      child.stdin.write(`${turnStartMessage}\n`);
+
+      const turnOutcome = await waitForTurnOutcome({
+        isCompleted: () => completed,
+        hasError: () => errorMessage,
+        latestEventAt: () => latestEventAt,
+        turnTimeoutMs: this.turnTimeoutMs,
+        readTimeoutMs: this.readTimeoutMs,
+        stallTimeoutMs: this.stallTimeoutMs,
+      });
+
+      if (turnOutcome === 'stalled') {
+        child.kill('SIGTERM');
+        return { status: 'stalled', activeIssue: false, state: this.snapshotState() };
+      }
+      if (turnOutcome === 'timeout') {
+        child.kill('SIGTERM');
+        return { status: 'timeout', activeIssue: false, state: this.snapshotState() };
+      }
+      if (errorMessage) {
+        const status = /rate\s*limit/i.test(errorMessage) ? 'rate_limited' : 'error';
+        child.kill('SIGTERM');
+        return {
+          status,
+          activeIssue: false,
+          state: this.snapshotState(),
+          errorMessage,
+        };
+      }
+
+      completed = false;
+      if (!activeIssue) {
+        child.stdin?.end();
+        child.kill('SIGTERM');
+        return {
+          status: 'completed',
+          activeIssue: false,
+          state: this.snapshotState(),
+        };
+      }
+    }
+
+    child.stdin?.end();
+    child.kill('SIGTERM');
+    return {
+      status: 'completed',
+      activeIssue: true,
+      state: this.snapshotState(),
+    };
+  }
+
+  private handleEventLine(line: string, onEvent: (event: JsonRpcEvent) => void): void {
+    try {
+      const parsed = JSON.parse(line) as JsonRpcEvent;
+      onEvent(parsed);
+    } catch {
+      // Ignore non-JSON log lines.
+    }
+  }
+
+  private applyEvent(event: JsonRpcEvent): void {
+    this.state.sessionId =
+      readString(event, ['params.session_id', 'session_id']) ?? this.state.sessionId;
+    this.state.threadId =
+      readString(event, ['params.thread_id', 'thread_id']) ?? this.state.threadId;
+    this.state.turnId = readString(event, ['params.turn_id', 'turn_id']) ?? this.state.turnId;
+
+    const inputTokens = readNumber(event, [
+      'params.usage.input_tokens',
+      'params.tokens.input',
+      'usage.input_tokens',
+      'tokens.input',
+    ]);
+    const outputTokens = readNumber(event, [
+      'params.usage.output_tokens',
+      'params.tokens.output',
+      'usage.output_tokens',
+      'tokens.output',
+    ]);
+    const totalTokens = readNumber(event, [
+      'params.usage.total_tokens',
+      'params.tokens.total',
+      'usage.total_tokens',
+      'tokens.total',
+    ]);
+
+    if (inputTokens !== undefined) {
+      this.state.usage.inputTokens = Math.max(this.state.usage.inputTokens, inputTokens);
+    }
+    if (outputTokens !== undefined) {
+      this.state.usage.outputTokens = Math.max(this.state.usage.outputTokens, outputTokens);
+    }
+    if (totalTokens !== undefined) {
+      this.state.usage.totalTokens = Math.max(this.state.usage.totalTokens, totalTokens);
+    } else {
+      this.state.usage.totalTokens = this.state.usage.inputTokens + this.state.usage.outputTokens;
+    }
+  }
+
+  private snapshotState(): CodexSessionState {
+    return {
+      sessionId: this.state.sessionId,
+      threadId: this.state.threadId,
+      turnId: this.state.turnId,
+      turnsStarted: this.state.turnsStarted,
+      turnsCompleted: this.state.turnsCompleted,
+      usage: {
+        inputTokens: this.state.usage.inputTokens,
+        outputTokens: this.state.usage.outputTokens,
+        totalTokens: this.state.usage.totalTokens,
+      },
+    };
+  }
+}
+
+async function waitForTurnOutcome(params: {
+  isCompleted: () => boolean;
+  hasError: () => string | undefined;
+  latestEventAt: () => number;
+  turnTimeoutMs: number;
+  readTimeoutMs: number;
+  stallTimeoutMs: number;
+}): Promise<'completed' | 'timeout' | 'stalled' | 'error'> {
+  const startedAt = Date.now();
+  while (true) {
+    if (params.hasError()) {
+      return 'error';
+    }
+    if (params.isCompleted()) {
+      return 'completed';
+    }
+
+    const now = Date.now();
+    if (now - startedAt > params.turnTimeoutMs) {
+      return 'timeout';
+    }
+    if (now - params.latestEventAt() > params.stallTimeoutMs) {
+      return 'stalled';
+    }
+
+    await sleep(Math.min(params.readTimeoutMs, 250));
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function readString(event: JsonRpcEvent, paths: string[]): string | undefined {
+  for (const path of paths) {
+    const value = readPath(event, path);
+    if (typeof value === 'string' && value.trim() !== '') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readNumber(event: JsonRpcEvent, paths: string[]): number | undefined {
+  for (const path of paths) {
+    const value = readPath(event, path);
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readBoolean(event: JsonRpcEvent, paths: string[]): boolean | undefined {
+  for (const path of paths) {
+    const value = readPath(event, path);
+    if (typeof value === 'boolean') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readPath(event: JsonRpcEvent, path: string): unknown {
+  const parts = path.split('.');
+  let current: unknown = event;
+  for (const part of parts) {
+    if (typeof current !== 'object' || current === null) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from './logging/logger.js';
 export * from './model/work-item.js';
 export * from './orchestrator/runtime.js';
 export * from './tracker/adapter.js';
+export * from './agent/codex-app-server.js';
 export * from './prompt/template.js';
 
 export {


### PR DESCRIPTION
Closes #30

## Summary

Implements the Codex app-server JSON-RPC stdio client (`src/agent/codex-app-server.ts`).

### What was done
- `CodexAppServerClient` class that spawns `codex app-server` as a subprocess
- JSON-RPC protocol: sends `thread.start` and `turn.start` messages via stdin
- Streams and parses stdout events for turn completion, active issues, token usage, errors, rate limits
- Tracks session state (`session_id`, `thread_id`, `turn_id`, token counters)
- Stall detection (no events within configurable timeout) kills the process
- Turn timeout terminates the current turn
- Multi-turn continuation up to `max_turns` when active issue is detected
- Rate limit error classification from stderr
- Full test suite with fake subprocess injection (4 tests, all passing)
- Exported from `src/index.ts`

### Chain position
- Branch: `feat/issue-30-codex-app-server-stdio`
- Base: `feat/issue-34-liquid-template-engine`
- Next: #29 (GitHub Projects tracker write path)