### PR TITLE
feat: implement GitHub Projects tracker write path (#29)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ export * from './logging/logger.js';
 export * from './model/work-item.js';
 export * from './orchestrator/runtime.js';
 export * from './tracker/adapter.js';
+export * from './tracker/graphql-client.js';
+export * from './tracker/github-projects-writer.js';
 export * from './agent/codex-app-server.js';
 export * from './prompt/template.js';
 

--- a/src/tracker/github-projects-writer.test.ts
+++ b/src/tracker/github-projects-writer.test.ts
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  GitHubProjectsWriter,
+  StatusFieldNotFoundError,
+  StatusOptionNotFoundError,
+} from './github-projects-writer.js';
+interface FakeGraphQLClient {
+  calls: Array<{ query: string; variables?: Record<string, unknown> }>;
+  query<T>(queryString: string, variables?: Record<string, unknown>): Promise<T>;
+}
+
+function makeFakeClient(responses: Array<{ data?: unknown; error?: string }>): FakeGraphQLClient {
+  const calls: Array<{ query: string; variables?: Record<string, unknown> }> = [];
+  let callIndex = 0;
+
+  return {
+    calls,
+    async query<T>(queryString: string, variables?: Record<string, unknown>): Promise<T> {
+      calls.push({ query: queryString, variables });
+      const resp = responses[callIndex] ?? responses[responses.length - 1];
+      callIndex += 1;
+      if (resp?.error) {
+        throw new Error(resp.error);
+      }
+      return resp?.data as T;
+    },
+  };
+}
+
+const FIELDS_RESPONSE = {
+  node: {
+    fields: {
+      nodes: [
+        {
+          id: 'field-1',
+          name: 'Status',
+          options: [
+            { id: 'opt-todo', name: 'Todo' },
+            { id: 'opt-ip', name: 'In Progress' },
+            { id: 'opt-done', name: 'Done' },
+          ],
+        },
+        {
+          id: 'field-2',
+          name: 'Priority',
+        },
+      ],
+    },
+  },
+};
+
+const MUTATION_RESPONSE = {
+  updateProjectV2ItemFieldValue: { clientMutationId: null },
+};
+
+test('markInProgress sends correct GraphQL mutation', async () => {
+  const client = makeFakeClient([{ data: FIELDS_RESPONSE }, { data: MUTATION_RESPONSE }]);
+
+  const writer = new GitHubProjectsWriter({
+    projectId: 'proj-1',
+    graphqlClient: client,
+  });
+
+  await writer.markInProgress('item-42');
+
+  assert.equal(client.calls.length, 2);
+  assert.ok(client.calls[0]!.query.includes('fields'));
+  assert.ok(client.calls[1]!.query.includes('updateProjectV2ItemFieldValue'));
+  assert.equal(client.calls[1]!.variables?.itemId, 'item-42');
+  assert.equal(client.calls[1]!.variables?.fieldId, 'field-1');
+  assert.equal(client.calls[1]!.variables?.optionId, 'opt-ip');
+});
+
+test('markDone sends correct mutation with Done option', async () => {
+  const client = makeFakeClient([{ data: FIELDS_RESPONSE }, { data: MUTATION_RESPONSE }]);
+
+  const writer = new GitHubProjectsWriter({
+    projectId: 'proj-1',
+    graphqlClient: client,
+  });
+
+  await writer.markDone('item-99');
+
+  assert.equal(client.calls[1]!.variables?.optionId, 'opt-done');
+});
+
+test('caches status field after first fetch', async () => {
+  const client = makeFakeClient([
+    { data: FIELDS_RESPONSE },
+    { data: MUTATION_RESPONSE },
+    { data: MUTATION_RESPONSE },
+  ]);
+
+  const writer = new GitHubProjectsWriter({
+    projectId: 'proj-1',
+    graphqlClient: client,
+  });
+
+  await writer.markInProgress('item-1');
+  await writer.markDone('item-2');
+
+  // Only 1 fields query + 2 mutations = 3 total
+  assert.equal(client.calls.length, 3);
+});
+
+test('throws StatusFieldNotFoundError when Status field missing', async () => {
+  const client = makeFakeClient([
+    {
+      data: {
+        node: { fields: { nodes: [{ id: 'f1', name: 'Priority' }] } },
+      },
+    },
+  ]);
+
+  const writer = new GitHubProjectsWriter({
+    projectId: 'proj-1',
+    graphqlClient: client,
+  });
+
+  await assert.rejects(() => writer.markInProgress('item-1'), StatusFieldNotFoundError);
+});
+
+test('throws StatusOptionNotFoundError for unknown status option', async () => {
+  const client = makeFakeClient([{ data: FIELDS_RESPONSE }]);
+
+  const writer = new GitHubProjectsWriter({
+    projectId: 'proj-1',
+    graphqlClient: client,
+    statusOptions: { inProgress: 'Working On It', done: 'Done' },
+  });
+
+  await assert.rejects(
+    () => writer.markInProgress('item-1'),
+    (err: StatusOptionNotFoundError) => {
+      assert.equal(err.name, 'StatusOptionNotFoundError');
+      assert.ok(err.availableOptions.includes('In Progress'));
+      return true;
+    },
+  );
+});
+
+test('supports custom status option names', async () => {
+  const customFieldsResponse = {
+    node: {
+      fields: {
+        nodes: [
+          {
+            id: 'field-1',
+            name: 'Status',
+            options: [
+              { id: 'opt-wip', name: 'WIP' },
+              { id: 'opt-shipped', name: 'Shipped' },
+            ],
+          },
+        ],
+      },
+    },
+  };
+
+  const client = makeFakeClient([{ data: customFieldsResponse }, { data: MUTATION_RESPONSE }]);
+
+  const writer = new GitHubProjectsWriter({
+    projectId: 'proj-1',
+    graphqlClient: client,
+    statusOptions: { inProgress: 'WIP', done: 'Shipped' },
+  });
+
+  await writer.markInProgress('item-1');
+  assert.equal(client.calls[1]!.variables?.optionId, 'opt-wip');
+});

--- a/src/tracker/github-projects-writer.ts
+++ b/src/tracker/github-projects-writer.ts
@@ -1,0 +1,170 @@
+export interface GraphQLQueryable {
+  query<T>(queryString: string, variables?: Record<string, unknown>): Promise<T>;
+}
+
+export interface StatusOptionMapping {
+  inProgress: string;
+  done: string;
+}
+
+const DEFAULT_STATUS_OPTIONS: StatusOptionMapping = {
+  inProgress: 'In Progress',
+  done: 'Done',
+};
+
+export interface GitHubProjectsWriterOptions {
+  projectId: string;
+  graphqlClient: GraphQLQueryable;
+  statusOptions?: Partial<StatusOptionMapping>;
+}
+
+interface StatusFieldInfo {
+  fieldId: string;
+  optionIds: Record<string, string>;
+}
+
+interface ProjectFieldNode {
+  id: string;
+  name: string;
+  options?: Array<{ id: string; name: string }>;
+}
+
+interface ProjectFieldsResponse {
+  node: {
+    fields: {
+      nodes: ProjectFieldNode[];
+    };
+  };
+}
+
+interface UpdateFieldResponse {
+  updateProjectV2ItemFieldValue: {
+    clientMutationId: string | null;
+  };
+}
+
+const FIELDS_QUERY = `
+  query($projectId: ID!) {
+    node(id: $projectId) {
+      ... on ProjectV2 {
+        fields(first: 50) {
+          nodes {
+            ... on ProjectV2SingleSelectField {
+              id
+              name
+              options { id name }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const UPDATE_MUTATION = `
+  mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+    updateProjectV2ItemFieldValue(input: {
+      projectId: $projectId
+      itemId: $itemId
+      fieldId: $fieldId
+      value: { singleSelectOptionId: $optionId }
+    }) {
+      clientMutationId
+    }
+  }
+`;
+
+export class StatusFieldNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StatusFieldNotFoundError';
+  }
+}
+
+export class StatusOptionNotFoundError extends Error {
+  constructor(
+    message: string,
+    public readonly availableOptions: string[],
+  ) {
+    super(message);
+    this.name = 'StatusOptionNotFoundError';
+  }
+}
+
+export class GitHubProjectsWriter {
+  private readonly projectId: string;
+  private readonly client: GraphQLQueryable;
+  private readonly statusOptionNames: StatusOptionMapping;
+  private statusFieldCache: StatusFieldInfo | undefined;
+
+  constructor(options: GitHubProjectsWriterOptions) {
+    this.projectId = options.projectId;
+    this.client = options.graphqlClient;
+    this.statusOptionNames = {
+      ...DEFAULT_STATUS_OPTIONS,
+      ...(options.statusOptions ?? {}),
+    };
+  }
+
+  async markInProgress(itemId: string): Promise<void> {
+    const field = await this.getStatusField();
+    const optionId = this.resolveOptionId(field, this.statusOptionNames.inProgress);
+    await this.updateField(itemId, field.fieldId, optionId);
+  }
+
+  async markDone(itemId: string): Promise<void> {
+    const field = await this.getStatusField();
+    const optionId = this.resolveOptionId(field, this.statusOptionNames.done);
+    await this.updateField(itemId, field.fieldId, optionId);
+  }
+
+  private resolveOptionId(field: StatusFieldInfo, optionName: string): string {
+    const optionId = field.optionIds[optionName];
+    if (!optionId) {
+      throw new StatusOptionNotFoundError(
+        `Status option "${optionName}" not found in project`,
+        Object.keys(field.optionIds),
+      );
+    }
+    return optionId;
+  }
+
+  private async updateField(itemId: string, fieldId: string, optionId: string): Promise<void> {
+    await this.client.query<UpdateFieldResponse>(UPDATE_MUTATION, {
+      projectId: this.projectId,
+      itemId,
+      fieldId,
+      optionId,
+    });
+  }
+
+  async getStatusField(): Promise<StatusFieldInfo> {
+    if (this.statusFieldCache) {
+      return this.statusFieldCache;
+    }
+
+    const data = await this.client.query<ProjectFieldsResponse>(FIELDS_QUERY, {
+      projectId: this.projectId,
+    });
+
+    const statusField = data.node.fields.nodes.find(
+      (f) => f.name === 'Status' && f.options !== undefined,
+    );
+
+    if (!statusField || !statusField.options) {
+      throw new StatusFieldNotFoundError('Status single-select field not found in project');
+    }
+
+    const optionIds: Record<string, string> = {};
+    for (const opt of statusField.options) {
+      optionIds[opt.name] = opt.id;
+    }
+
+    this.statusFieldCache = {
+      fieldId: statusField.id,
+      optionIds,
+    };
+
+    return this.statusFieldCache;
+  }
+}

--- a/src/tracker/graphql-client.ts
+++ b/src/tracker/graphql-client.ts
@@ -1,0 +1,57 @@
+export interface GraphQLClientOptions {
+  token: string;
+  baseUrl?: string;
+}
+
+export interface GraphQLResponse<T = unknown> {
+  data?: T;
+  errors?: Array<{ message: string; type?: string; path?: string[] }>;
+}
+
+export class GraphQLError extends Error {
+  constructor(
+    message: string,
+    public readonly errors: Array<{ message: string; type?: string; path?: string[] }>,
+  ) {
+    super(message);
+    this.name = 'GraphQLError';
+  }
+}
+
+export class GraphQLClient {
+  private readonly token: string;
+  private readonly baseUrl: string;
+
+  constructor(options: GraphQLClientOptions) {
+    this.token = options.token;
+    this.baseUrl = options.baseUrl ?? 'https://api.github.com/graphql';
+  }
+
+  async query<T = unknown>(queryString: string, variables?: Record<string, unknown>): Promise<T> {
+    const response = await fetch(this.baseUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `bearer ${this.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query: queryString, variables }),
+    });
+
+    if (!response.ok) {
+      throw new GraphQLError(`GitHub GraphQL request failed: ${response.status}`, []);
+    }
+
+    const json = (await response.json()) as GraphQLResponse<T>;
+
+    if (json.errors && json.errors.length > 0) {
+      const messages = json.errors.map((e) => e.message).join('; ');
+      throw new GraphQLError(`GraphQL errors: ${messages}`, json.errors);
+    }
+
+    if (!json.data) {
+      throw new GraphQLError('GraphQL response missing data', []);
+    }
+
+    return json.data;
+  }
+}


### PR DESCRIPTION
Closes #29

## Summary

Implements `markInProgress` and `markDone` for GitHub Projects via GraphQL `updateProjectV2ItemFieldValue` mutation.

### What was done
- `GraphQLClient` (`src/tracker/graphql-client.ts`): typed GraphQL client with error handling
- `GitHubProjectsWriter` (`src/tracker/github-projects-writer.ts`):
  - Fetches Status field and option IDs via ProjectV2 fields query
  - Caches field metadata after first fetch
  - `markInProgress(itemId)` / `markDone(itemId)` update the Status field
  - Configurable status option names (defaults: "In Progress", "Done")
  - Typed errors: `StatusFieldNotFoundError`, `StatusOptionNotFoundError`, `GraphQLError`
- 6 tests covering success, caching, missing field, unknown option, custom names
- Exported from `src/index.ts`

### Chain position
- Branch: `feat/issue-29-tracker-write-path`
- Base: `feat/issue-30-codex-app-server-stdio`
- Next: #31 (workspace lifecycle hooks)