### PR TITLE
feat: implement workspace lifecycle hooks (#31)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from './tracker/adapter.js';
 export * from './tracker/graphql-client.js';
 export * from './tracker/github-projects-writer.js';
 export * from './agent/codex-app-server.js';
+export * from './workspace/hooks.js';
 export * from './prompt/template.js';
 
 export {

--- a/src/workspace/hooks.test.ts
+++ b/src/workspace/hooks.test.ts
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { HookRunner, HookFailureError } from './hooks.js';
+import type { Logger } from '../logging/logger.js';
+
+class CapturingLogger implements Logger {
+  public readonly messages: Array<{ message: string; context?: Record<string, unknown> }> = [];
+  info(message: string, context?: Record<string, unknown>): void {
+    this.messages.push({ message, context });
+  }
+  warn(_m: string, _c?: Record<string, unknown>): void {}
+  error(message: string, context?: Record<string, unknown>): void {
+    this.messages.push({ message, context });
+  }
+}
+
+function fakeExec(exitCode: number, stdout = '', stderr = '') {
+  return async (_cmd: string, _args: string[], _opts: { cwd: string; timeout: number }) => ({
+    stdout,
+    stderr,
+    exitCode,
+  });
+}
+
+test('afterCreate succeeds when hook exits 0', async () => {
+  const logger = new CapturingLogger();
+  const runner = new HookRunner({
+    hooks: { after_create: 'echo setup' },
+    logger,
+    exec: fakeExec(0, 'setup\n'),
+  });
+
+  const result = await runner.afterCreate('/tmp/ws');
+  assert.equal(result.success, true);
+  assert.equal(result.hook, 'after_create');
+  assert.ok(logger.messages.some((m) => m.message === 'hook.success'));
+});
+
+test('afterCreate returns failure when hook exits non-zero', async () => {
+  const logger = new CapturingLogger();
+  const runner = new HookRunner({
+    hooks: { after_create: 'exit 1' },
+    logger,
+    exec: fakeExec(1, '', 'bad thing'),
+  });
+
+  const result = await runner.afterCreate('/tmp/ws');
+  assert.equal(result.success, false);
+  assert.equal(result.exitCode, 1);
+  assert.ok(logger.messages.some((m) => m.message === 'hook.failure'));
+});
+
+test('afterCreate detects timeout (exit code -1)', async () => {
+  const logger = new CapturingLogger();
+  const runner = new HookRunner({
+    hooks: { after_create: 'sleep 999' },
+    logger,
+    exec: fakeExec(-1),
+  });
+
+  const result = await runner.afterCreate('/tmp/ws');
+  assert.equal(result.success, false);
+  assert.equal(result.timedOut, true);
+  assert.ok(logger.messages.some((m) => m.message === 'hook.timeout'));
+});
+
+test('beforeRun returns failure on non-zero exit', async () => {
+  const logger = new CapturingLogger();
+  const runner = new HookRunner({
+    hooks: { before_run: 'false' },
+    logger,
+    exec: fakeExec(2, '', 'precondition failed'),
+  });
+
+  const result = await runner.beforeRun('/tmp/ws');
+  assert.equal(result.success, false);
+});
+
+test('afterRun returns result even on failure (non-fatal)', async () => {
+  const logger = new CapturingLogger();
+  const runner = new HookRunner({
+    hooks: { after_run: 'cleanup' },
+    logger,
+    exec: fakeExec(1, '', 'cleanup error'),
+  });
+
+  const result = await runner.afterRun('/tmp/ws');
+  assert.equal(result.success, false);
+  // Should not throw — just returns the result
+  assert.equal(result.hook, 'after_run');
+});
+
+test('beforeRemove returns result even on failure (non-fatal)', async () => {
+  const logger = new CapturingLogger();
+  const runner = new HookRunner({
+    hooks: { before_remove: 'pre-cleanup' },
+    logger,
+    exec: fakeExec(1),
+  });
+
+  const result = await runner.beforeRemove('/tmp/ws');
+  assert.equal(result.success, false);
+  assert.equal(result.hook, 'before_remove');
+});
+
+test('skips hook when not configured', async () => {
+  const logger = new CapturingLogger();
+  const runner = new HookRunner({
+    hooks: {},
+    logger,
+  });
+
+  const result = await runner.afterCreate('/tmp/ws');
+  assert.equal(result.success, true);
+  assert.equal(logger.messages.length, 0);
+});
+
+test('passes cwd and timeout to exec', async () => {
+  const logger = new CapturingLogger();
+  const calls: Array<{ cmd: string; args: string[]; cwd: string; timeout: number }> = [];
+
+  const runner = new HookRunner({
+    hooks: { before_run: 'npm install' },
+    timeoutMs: 30_000,
+    logger,
+    exec: async (cmd, args, opts) => {
+      calls.push({ cmd, args, cwd: opts.cwd, timeout: opts.timeout });
+      return { stdout: '', stderr: '', exitCode: 0 };
+    },
+  });
+
+  await runner.beforeRun('/workspace/item-42');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.cmd, 'sh');
+  assert.deepEqual(calls[0]!.args, ['-lc', 'npm install']);
+  assert.equal(calls[0]!.cwd, '/workspace/item-42');
+  assert.equal(calls[0]!.timeout, 30_000);
+});
+
+test('HookFailureError includes result details', () => {
+  const err = new HookFailureError({
+    hook: 'after_create',
+    success: false,
+    exitCode: 127,
+  });
+  assert.equal(err.name, 'HookFailureError');
+  assert.match(err.message, /after_create/);
+  assert.match(err.message, /127/);
+  assert.equal(err.result.exitCode, 127);
+});

--- a/src/workspace/hooks.ts
+++ b/src/workspace/hooks.ts
@@ -1,0 +1,174 @@
+import { execFile } from 'node:child_process';
+import type { Logger } from '../logging/logger.js';
+
+export interface WorkspaceHooks {
+  after_create?: string;
+  before_run?: string;
+  after_run?: string;
+  before_remove?: string;
+}
+
+export interface HookRunnerOptions {
+  hooks: WorkspaceHooks;
+  timeoutMs?: number;
+  logger: Logger;
+  exec?: ExecFn;
+}
+
+export interface HookResult {
+  hook: string;
+  success: boolean;
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+  timedOut?: boolean;
+  error?: string;
+}
+
+type ExecFn = (
+  command: string,
+  args: string[],
+  options: { cwd: string; timeout: number },
+) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+function defaultExec(
+  command: string,
+  args: string[],
+  options: { cwd: string; timeout: number },
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    const proc = execFile(command, args, {
+      cwd: options.cwd,
+      timeout: options.timeout,
+      shell: false,
+      maxBuffer: 1024 * 1024,
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout?.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    proc.stderr?.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+
+    proc.on('error', (err) => {
+      if ('killed' in proc && proc.killed) {
+        resolve({ stdout, stderr, exitCode: -1 });
+      } else {
+        reject(err);
+      }
+    });
+
+    proc.on('close', (code) => {
+      resolve({ stdout, stderr, exitCode: code ?? 0 });
+    });
+  });
+}
+
+export class HookRunner {
+  private readonly hooks: WorkspaceHooks;
+  private readonly timeoutMs: number;
+  private readonly logger: Logger;
+  private readonly execFn: ExecFn;
+
+  constructor(options: HookRunnerOptions) {
+    this.hooks = options.hooks;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.logger = options.logger;
+    this.execFn = options.exec ?? defaultExec;
+  }
+
+  /**
+   * Run after_create hook. Failure is fatal — caller should clean up the workspace.
+   */
+  async afterCreate(cwd: string): Promise<HookResult> {
+    return this.runHook('after_create', cwd);
+  }
+
+  /**
+   * Run before_run hook. Failure is fatal to the current run attempt.
+   */
+  async beforeRun(cwd: string): Promise<HookResult> {
+    return this.runHook('before_run', cwd);
+  }
+
+  /**
+   * Run after_run hook. Failure is logged and ignored.
+   */
+  async afterRun(cwd: string): Promise<HookResult> {
+    return this.runHookSafe('after_run', cwd);
+  }
+
+  /**
+   * Run before_remove hook. Failure is logged and ignored; cleanup proceeds.
+   */
+  async beforeRemove(cwd: string): Promise<HookResult> {
+    return this.runHookSafe('before_remove', cwd);
+  }
+
+  private async runHook(hookName: keyof WorkspaceHooks, cwd: string): Promise<HookResult> {
+    const command = this.hooks[hookName];
+    if (!command) {
+      return { hook: hookName, success: true };
+    }
+
+    this.logger.info(`hook.start`, { hook: hookName, command, cwd });
+
+    try {
+      const result = await this.execFn('sh', ['-lc', command], {
+        cwd,
+        timeout: this.timeoutMs,
+      });
+
+      const timedOut = result.exitCode === -1;
+      const success = result.exitCode === 0;
+
+      if (success) {
+        this.logger.info(`hook.success`, { hook: hookName });
+      } else if (timedOut) {
+        this.logger.error(`hook.timeout`, { hook: hookName, timeoutMs: this.timeoutMs });
+      } else {
+        this.logger.error(`hook.failure`, {
+          hook: hookName,
+          exitCode: result.exitCode,
+          stderr: result.stderr.slice(0, 500),
+        });
+      }
+
+      return {
+        hook: hookName,
+        success,
+        exitCode: result.exitCode,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        timedOut,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error(`hook.error`, { hook: hookName, error: message });
+      return {
+        hook: hookName,
+        success: false,
+        error: message,
+      };
+    }
+  }
+
+  private async runHookSafe(hookName: keyof WorkspaceHooks, cwd: string): Promise<HookResult> {
+    const result = await this.runHook(hookName, cwd);
+    // Always return the result but don't throw — caller decides severity
+    return result;
+  }
+}
+
+export class HookFailureError extends Error {
+  constructor(public readonly result: HookResult) {
+    super(`Hook "${result.hook}" failed: ${result.error ?? `exit code ${result.exitCode}`}`);
+    this.name = 'HookFailureError';
+  }
+}


### PR DESCRIPTION
Closes #31

## Summary

Implements SPEC-compliant workspace lifecycle hooks (`after_create`, `before_run`, `after_run`, `before_remove`).

### What was done
- `HookRunner` class (`src/workspace/hooks.ts`)
  - Executes hooks as `sh -lc` commands with workspace cwd
  - Configurable timeout (default 60s)
  - Failure semantics per SPEC:
    - `after_create` / `before_run` failure → fatal (caller decides cleanup)
    - `after_run` / `before_remove` failure → logged, non-fatal
  - Structured logging for start/success/failure/timeout
- `HookFailureError` for typed error propagation
- 9 tests covering success, failure, timeout, skip, cwd/timeout passthrough
- Exported from `src/index.ts`

### Chain position
- Branch: `feat/issue-31-workspace-lifecycle-hooks`
- Base: `feat/issue-29-tracker-write-path`
- Next: #32 (reconciliation)