### PR TITLE
feat: implement reconciliation for running jobs (#32)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * from './tracker/graphql-client.js';
 export * from './tracker/github-projects-writer.js';
 export * from './agent/codex-app-server.js';
 export * from './workspace/hooks.js';
+export * from './orchestrator/reconciler.js';
 export * from './prompt/template.js';
 
 export {

--- a/src/orchestrator/reconciler.test.ts
+++ b/src/orchestrator/reconciler.test.ts
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { Reconciler } from './reconciler.js';
+import type { RunningJob, TrackerStateProvider } from './reconciler.js';
+import type { WorkItemState } from '../model/work-item.js';
+import type { Logger } from '../logging/logger.js';
+
+class CapturingLogger implements Logger {
+  public readonly messages: Array<{ message: string; context?: Record<string, unknown> }> = [];
+  info(message: string, context?: Record<string, unknown>): void {
+    this.messages.push({ message, context });
+  }
+  warn(message: string, context?: Record<string, unknown>): void {
+    this.messages.push({ message, context });
+  }
+  error(message: string, context?: Record<string, unknown>): void {
+    this.messages.push({ message, context });
+  }
+}
+
+function makeWorker() {
+  const killed: string[] = [];
+  const cleaned: string[] = [];
+  const retried: string[] = [];
+  return {
+    killed,
+    cleaned,
+    retried,
+    kill(itemId: string) {
+      killed.push(itemId);
+    },
+    async cleanupWorkspace(itemId: string) {
+      cleaned.push(itemId);
+    },
+    scheduleRetry(itemId: string) {
+      retried.push(itemId);
+    },
+  };
+}
+
+function makeTracker(states: Record<string, WorkItemState | undefined>): TrackerStateProvider {
+  return {
+    async getItemState(itemId: string) {
+      return states[itemId];
+    },
+  };
+}
+
+const now = Date.now();
+
+test('kills stalled workers and schedules retry', async () => {
+  const logger = new CapturingLogger();
+  const worker = makeWorker();
+  const tracker = makeTracker({ 'item-1': 'in_progress' });
+
+  const reconciler = new Reconciler({
+    stallTimeoutMs: 5000,
+    logger,
+    tracker,
+    worker,
+  });
+
+  const jobs: RunningJob[] = [
+    { itemId: 'item-1', startedAt: now - 10000, lastEventAt: now - 10000 },
+  ];
+
+  const result = await reconciler.reconcile(jobs);
+
+  assert.deepEqual(result.staleKilled, ['item-1']);
+  assert.deepEqual(worker.killed, ['item-1']);
+  assert.deepEqual(worker.retried, ['item-1']);
+});
+
+test('terminates worker and cleans up for terminal state (done)', async () => {
+  const logger = new CapturingLogger();
+  const worker = makeWorker();
+  const tracker = makeTracker({ 'item-2': 'done' });
+
+  const reconciler = new Reconciler({
+    stallTimeoutMs: 60000,
+    logger,
+    tracker,
+    worker,
+  });
+
+  const jobs: RunningJob[] = [{ itemId: 'item-2', startedAt: now, lastEventAt: now }];
+
+  const result = await reconciler.reconcile(jobs);
+
+  assert.deepEqual(result.terminalKilled, ['item-2']);
+  assert.deepEqual(worker.killed, ['item-2']);
+  assert.deepEqual(worker.cleaned, ['item-2']);
+});
+
+test('terminates worker without cleanup for blocked state', async () => {
+  const logger = new CapturingLogger();
+  const worker = makeWorker();
+  const tracker = makeTracker({ 'item-3': 'blocked' });
+
+  const reconciler = new Reconciler({
+    stallTimeoutMs: 60000,
+    logger,
+    tracker,
+    worker,
+  });
+
+  const jobs: RunningJob[] = [{ itemId: 'item-3', startedAt: now, lastEventAt: now }];
+
+  const result = await reconciler.reconcile(jobs);
+
+  assert.deepEqual(result.nonActiveKilled, ['item-3']);
+  assert.deepEqual(worker.killed, ['item-3']);
+  assert.deepEqual(worker.cleaned, []);
+});
+
+test('handles tracker API failure gracefully', async () => {
+  const logger = new CapturingLogger();
+  const worker = makeWorker();
+  const tracker: TrackerStateProvider = {
+    async getItemState() {
+      throw new Error('API down');
+    },
+  };
+
+  const reconciler = new Reconciler({
+    stallTimeoutMs: 60000,
+    logger,
+    tracker,
+    worker,
+  });
+
+  const jobs: RunningJob[] = [{ itemId: 'item-4', startedAt: now, lastEventAt: now }];
+
+  const result = await reconciler.reconcile(jobs);
+
+  assert.deepEqual(result.trackerErrors, ['item-4']);
+  assert.deepEqual(worker.killed, []);
+  assert.ok(logger.messages.some((m) => m.message === 'reconcile.tracker_error'));
+});
+
+test('keeps active (in_progress) items running', async () => {
+  const logger = new CapturingLogger();
+  const worker = makeWorker();
+  const tracker = makeTracker({ 'item-5': 'in_progress' });
+
+  const reconciler = new Reconciler({
+    stallTimeoutMs: 60000,
+    logger,
+    tracker,
+    worker,
+  });
+
+  const jobs: RunningJob[] = [{ itemId: 'item-5', startedAt: now, lastEventAt: now }];
+
+  const result = await reconciler.reconcile(jobs);
+
+  assert.deepEqual(result.staleKilled, []);
+  assert.deepEqual(result.terminalKilled, []);
+  assert.deepEqual(result.nonActiveKilled, []);
+  assert.deepEqual(worker.killed, []);
+});
+
+test('handles item not found (undefined state)', async () => {
+  const logger = new CapturingLogger();
+  const worker = makeWorker();
+  const tracker = makeTracker({});
+
+  const reconciler = new Reconciler({
+    stallTimeoutMs: 60000,
+    logger,
+    tracker,
+    worker,
+  });
+
+  const jobs: RunningJob[] = [{ itemId: 'item-gone', startedAt: now, lastEventAt: now }];
+
+  const result = await reconciler.reconcile(jobs);
+
+  assert.deepEqual(result.nonActiveKilled, ['item-gone']);
+  assert.deepEqual(worker.killed, ['item-gone']);
+  assert.deepEqual(worker.cleaned, []);
+});

--- a/src/orchestrator/reconciler.ts
+++ b/src/orchestrator/reconciler.ts
@@ -1,0 +1,124 @@
+import type { Logger } from '../logging/logger.js';
+import type { WorkItemState } from '../model/work-item.js';
+
+export interface RunningJob {
+  itemId: string;
+  startedAt: number;
+  lastEventAt: number;
+}
+
+export interface TrackerStateProvider {
+  getItemState(itemId: string): Promise<WorkItemState | undefined>;
+}
+
+export interface WorkerController {
+  kill(itemId: string): void;
+  cleanupWorkspace(itemId: string): Promise<void>;
+  scheduleRetry(itemId: string): void;
+}
+
+export interface ReconcilerOptions {
+  stallTimeoutMs: number;
+  logger: Logger;
+  tracker: TrackerStateProvider;
+  worker: WorkerController;
+}
+
+const TERMINAL_STATES: Set<WorkItemState> = new Set(['done']);
+
+export interface ReconcileResult {
+  staleKilled: string[];
+  terminalKilled: string[];
+  nonActiveKilled: string[];
+  trackerErrors: string[];
+}
+
+export class Reconciler {
+  private readonly stallTimeoutMs: number;
+  private readonly logger: Logger;
+  private readonly tracker: TrackerStateProvider;
+  private readonly worker: WorkerController;
+
+  constructor(options: ReconcilerOptions) {
+    this.stallTimeoutMs = options.stallTimeoutMs;
+    this.logger = options.logger;
+    this.tracker = options.tracker;
+    this.worker = options.worker;
+  }
+
+  async reconcile(runningJobs: RunningJob[]): Promise<ReconcileResult> {
+    const result: ReconcileResult = {
+      staleKilled: [],
+      terminalKilled: [],
+      nonActiveKilled: [],
+      trackerErrors: [],
+    };
+
+    const now = Date.now();
+
+    // Part A: Stall detection
+    for (const job of runningJobs) {
+      const elapsed = now - job.lastEventAt;
+      if (elapsed > this.stallTimeoutMs) {
+        this.logger.info('reconcile.stall', {
+          itemId: job.itemId,
+          elapsedMs: elapsed,
+          stallTimeoutMs: this.stallTimeoutMs,
+        });
+        this.worker.kill(job.itemId);
+        this.worker.scheduleRetry(job.itemId);
+        result.staleKilled.push(job.itemId);
+      }
+    }
+
+    // Part B: Tracker state refresh
+    const nonStaleJobs = runningJobs.filter((j) => !result.staleKilled.includes(j.itemId));
+
+    for (const job of nonStaleJobs) {
+      let state: WorkItemState | undefined;
+      try {
+        state = await this.tracker.getItemState(job.itemId);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.warn('reconcile.tracker_error', {
+          itemId: job.itemId,
+          error: message,
+        });
+        result.trackerErrors.push(job.itemId);
+        continue;
+      }
+
+      if (state === undefined) {
+        // Item no longer exists — terminate without cleanup
+        this.logger.info('reconcile.not_found', { itemId: job.itemId });
+        this.worker.kill(job.itemId);
+        result.nonActiveKilled.push(job.itemId);
+        continue;
+      }
+
+      if (TERMINAL_STATES.has(state)) {
+        this.logger.info('reconcile.terminal', { itemId: job.itemId, state });
+        this.worker.kill(job.itemId);
+        await this.worker.cleanupWorkspace(job.itemId);
+        result.terminalKilled.push(job.itemId);
+        continue;
+      }
+
+      if (state !== 'in_progress' && state !== 'todo') {
+        // Blocked or unknown — terminate without cleanup
+        this.logger.info('reconcile.non_active', { itemId: job.itemId, state });
+        this.worker.kill(job.itemId);
+        result.nonActiveKilled.push(job.itemId);
+      }
+    }
+
+    this.logger.info('reconcile.complete', {
+      staleKilled: result.staleKilled.length,
+      terminalKilled: result.terminalKilled.length,
+      nonActiveKilled: result.nonActiveKilled.length,
+      trackerErrors: result.trackerErrors.length,
+    });
+
+    return result;
+  }
+}


### PR DESCRIPTION
Closes #32

## Summary

Implements SPEC reconciliation: syncs running jobs with tracker state on every tick.

### What was done
- `Reconciler` class (`src/orchestrator/reconciler.ts`)
  - Part A: Stall detection — kills workers exceeding `stallTimeoutMs` since last event, schedules retry
  - Part B: Tracker state refresh — fetches current state for running items:
    - Terminal (done) → kill + cleanup workspace
    - Not found / blocked → kill without cleanup
    - Active (in_progress/todo) → keep running
    - API failure → skip, retry next tick
- 6 tests covering stall, terminal, blocked, API error, active, not-found
- Exported from `src/index.ts`

### Chain position
- Branch: `feat/issue-32-reconciliation`
- Base: `feat/issue-31-workspace-lifecycle-hooks`
- Next: #33 (WORKFLOW.md hot-reload)