### PR TITLE
feat: implement WORKFLOW.md hot-reload (#33)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export * from './tracker/github-projects-writer.js';
 export * from './agent/codex-app-server.js';
 export * from './workspace/hooks.js';
 export * from './orchestrator/reconciler.js';
+export * from './workflow/hot-reload.js';
 export * from './prompt/template.js';
 
 export {

--- a/src/workflow/hot-reload.test.ts
+++ b/src/workflow/hot-reload.test.ts
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { WorkflowHotReloader } from './hot-reload.js';
+import type { LoadedWorkflowContract, WorkflowLoader } from './contract.js';
+import type { Logger } from '../logging/logger.js';
+
+type WatchCallback = (eventType: string) => void;
+
+class CapturingLogger implements Logger {
+  public readonly messages: Array<{ message: string; context?: Record<string, unknown> }> = [];
+  info(message: string, context?: Record<string, unknown>): void {
+    this.messages.push({ message, context });
+  }
+  warn(_m: string, _c?: Record<string, unknown>): void {}
+  error(message: string, context?: Record<string, unknown>): void {
+    this.messages.push({ message, context });
+  }
+}
+
+function makeContract(overrides: Partial<LoadedWorkflowContract> = {}): LoadedWorkflowContract {
+  return {
+    tracker: {
+      kind: 'github_projects',
+      github: { owner: 'test', projectNumber: 1, tokenEnv: 'TOKEN' },
+    },
+    polling: { intervalMs: 60000, maxConcurrency: 1 },
+    workspace: { baseDir: '/tmp' },
+    agent: { command: 'codex' },
+    prompt_template: 'do work',
+    ...overrides,
+  };
+}
+
+test('triggers onReload when file change is detected', async () => {
+  const logger = new CapturingLogger();
+  let watchCallback: WatchCallback | undefined;
+  const reloaded: LoadedWorkflowContract[] = [];
+
+  const newContract = makeContract({
+    polling: { intervalMs: 30000, maxConcurrency: 4 },
+  });
+
+  const loader: WorkflowLoader = {
+    async load() {
+      return newContract;
+    },
+  };
+
+  const reloader = new WorkflowHotReloader({
+    workflowPath: '/fake/WORKFLOW.md',
+    loader,
+    logger,
+    debounceMs: 5,
+    onReload: (c) => reloaded.push(c),
+    watch: (_path, cb) => {
+      watchCallback = cb;
+      return { close: () => {} };
+    },
+  });
+
+  reloader.start(makeContract());
+
+  // Simulate file change
+  assert.ok(watchCallback, 'watchCallback should be set');
+  watchCallback!('change');
+
+  // Wait for debounce + async reload
+  await new Promise((r) => setTimeout(r, 50));
+
+  assert.equal(reloaded.length, 1);
+  assert.equal(reloaded[0]!.polling.intervalMs, 30000);
+  assert.equal(reloaded[0]!.polling.maxConcurrency, 4);
+  assert.ok(logger.messages.some((m) => m.message === 'hot-reload.applied'));
+
+  reloader.stop();
+});
+
+test('keeps last good config when reload fails', async () => {
+  const logger = new CapturingLogger();
+  let watchCallback: WatchCallback | undefined;
+  const reloaded: LoadedWorkflowContract[] = [];
+
+  const loader: WorkflowLoader = {
+    async load() {
+      throw new Error('invalid YAML');
+    },
+  };
+
+  const initialContract = makeContract();
+
+  const reloader = new WorkflowHotReloader({
+    workflowPath: '/fake/WORKFLOW.md',
+    loader,
+    logger,
+    debounceMs: 5,
+    onReload: (c) => reloaded.push(c),
+    watch: (_path, cb) => {
+      watchCallback = cb;
+      return { close: () => {} };
+    },
+  });
+
+  reloader.start(initialContract);
+  watchCallback!('change');
+
+  await new Promise((r) => setTimeout(r, 50));
+
+  assert.equal(reloaded.length, 0);
+  assert.ok(logger.messages.some((m) => m.message === 'hot-reload.invalid'));
+  assert.equal(reloader.getLastGoodContract(), initialContract);
+
+  reloader.stop();
+});
+
+test('debounces rapid file changes', async () => {
+  const logger = new CapturingLogger();
+  let watchCallback: WatchCallback | undefined;
+  let loadCount = 0;
+
+  const loader: WorkflowLoader = {
+    async load() {
+      loadCount += 1;
+      return makeContract();
+    },
+  };
+
+  const reloader = new WorkflowHotReloader({
+    workflowPath: '/fake/WORKFLOW.md',
+    loader,
+    logger,
+    debounceMs: 30,
+    onReload: () => {},
+    watch: (_path, cb) => {
+      watchCallback = cb;
+      return { close: () => {} };
+    },
+  });
+
+  reloader.start(makeContract());
+
+  // Fire 5 rapid changes
+  for (let i = 0; i < 5; i++) {
+    watchCallback!('change');
+  }
+
+  await new Promise((r) => setTimeout(r, 100));
+
+  // Should only load once due to debounce
+  assert.equal(loadCount, 1);
+
+  reloader.stop();
+});
+
+test('stop cancels pending debounce', async () => {
+  const logger = new CapturingLogger();
+  let watchCallback: WatchCallback | undefined;
+  let loadCount = 0;
+
+  const loader: WorkflowLoader = {
+    async load() {
+      loadCount += 1;
+      return makeContract();
+    },
+  };
+
+  const reloader = new WorkflowHotReloader({
+    workflowPath: '/fake/WORKFLOW.md',
+    loader,
+    logger,
+    debounceMs: 100,
+    onReload: () => {},
+    watch: (_path, cb) => {
+      watchCallback = cb;
+      return { close: () => {} };
+    },
+  });
+
+  reloader.start(makeContract());
+  watchCallback!('change');
+  reloader.stop();
+
+  await new Promise((r) => setTimeout(r, 150));
+  assert.equal(loadCount, 0);
+});

--- a/src/workflow/hot-reload.ts
+++ b/src/workflow/hot-reload.ts
@@ -1,0 +1,98 @@
+import { watch, type FSWatcher } from 'node:fs';
+import type { Logger } from '../logging/logger.js';
+import type { LoadedWorkflowContract, WorkflowLoader } from './contract.js';
+
+export interface HotReloadOptions {
+  workflowPath: string;
+  loader: WorkflowLoader;
+  logger: Logger;
+  debounceMs?: number;
+  onReload: (contract: LoadedWorkflowContract) => void;
+  watch?: WatchFn;
+}
+
+type WatchFn = (path: string, callback: (eventType: string) => void) => { close: () => void };
+
+const DEFAULT_DEBOUNCE_MS = 500;
+
+export class WorkflowHotReloader {
+  private readonly workflowPath: string;
+  private readonly loader: WorkflowLoader;
+  private readonly logger: Logger;
+  private readonly debounceMs: number;
+  private readonly onReload: (contract: LoadedWorkflowContract) => void;
+  private readonly watchFn: WatchFn;
+
+  private watcher: { close: () => void } | null = null;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastGoodContract: LoadedWorkflowContract | null = null;
+
+  constructor(options: HotReloadOptions) {
+    this.workflowPath = options.workflowPath;
+    this.loader = options.loader;
+    this.logger = options.logger;
+    this.debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    this.onReload = options.onReload;
+    this.watchFn =
+      options.watch ??
+      ((path, cb) => {
+        const w: FSWatcher = watch(path, (eventType) => cb(eventType));
+        return { close: () => w.close() };
+      });
+  }
+
+  start(initialContract: LoadedWorkflowContract): void {
+    this.lastGoodContract = initialContract;
+
+    this.watcher = this.watchFn(this.workflowPath, (_eventType) => {
+      this.scheduleReload();
+    });
+
+    this.logger.info('hot-reload.watching', { path: this.workflowPath });
+  }
+
+  stop(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+    }
+    this.logger.info('hot-reload.stopped');
+  }
+
+  private scheduleReload(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      void this.reload();
+    }, this.debounceMs);
+  }
+
+  private async reload(): Promise<void> {
+    this.logger.info('hot-reload.reloading', { path: this.workflowPath });
+
+    try {
+      const contract = await this.loader.load(this.workflowPath);
+      this.lastGoodContract = contract;
+      this.onReload(contract);
+      this.logger.info('hot-reload.applied', {
+        intervalMs: contract.polling.intervalMs,
+        maxConcurrency: contract.polling.maxConcurrency,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error('hot-reload.invalid', {
+        error: message,
+        keepingPrevious: true,
+      });
+    }
+  }
+
+  getLastGoodContract(): LoadedWorkflowContract | null {
+    return this.lastGoodContract;
+  }
+}


### PR DESCRIPTION
Closes #33

## Summary

Implements dynamic WORKFLOW.md hot-reload with file watching and debounced config re-apply.

### What was done
- `WorkflowHotReloader` class (`src/workflow/hot-reload.ts`)
  - Watches WORKFLOW.md via `fs.watch` (injectable for testing)
  - Debounced reload (default 500ms) prevents rapid re-parse
  - On valid change: re-parses and calls `onReload` callback with new contract
  - On invalid change: logs error, keeps last known good config
  - `start(initialContract)` / `stop()` lifecycle
  - `getLastGoodContract()` for current state inspection
- 4 tests: reload on change, invalid keeps last good, debounce dedup, stop cancels pending
- Exported from `src/index.ts`

### Chain position
- Branch: `feat/issue-33-workflow-hot-reload`
- Base: `feat/issue-32-reconciliation`
- This is the FINAL issue in the chain 🎉