### PR TITLE
feat: [SPEC parity] tracker adapter + normalized work-item model (#46)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from './model/work-item.js';
 export * from './orchestrator/runtime.js';
 export * from './tracker/adapter.js';
 export * from './tracker/graphql-client.js';
+export * from './tracker/github-projects-client.js';
 export * from './tracker/github-projects-writer.js';
 export * from './agent/codex-app-server.js';
 export * from './workspace/hooks.js';

--- a/src/model/work-item.ts
+++ b/src/model/work-item.ts
@@ -2,12 +2,49 @@ export type WorkItemState = "todo" | "in_progress" | "blocked" | "done";
 
 export interface NormalizedWorkItem {
   id: string;
+  identifier?: string;
   number?: number;
   title: string;
   body?: string;
+  description?: string;
   state: WorkItemState;
+  priority?: number | null;
   labels: string[];
+  blocked_by?: string[];
   assignees: string[];
+  created_at?: string;
+  updated_at?: string;
   url?: string;
-  updatedAt: string;
+  // backward-compatible aliases
+  updatedAt?: string;
+}
+
+const STATE_ALIAS: Record<string, WorkItemState> = {
+  todo: "todo",
+  backlog: "todo",
+  "to do": "todo",
+  in_progress: "in_progress",
+  inprogress: "in_progress",
+  "in progress": "in_progress",
+  blocked: "blocked",
+  done: "done",
+  completed: "done",
+  closed: "done",
+};
+
+export function normalizeState(value: string): WorkItemState {
+  const normalized = value.trim().toLowerCase();
+  const mapped = STATE_ALIAS[normalized];
+  if (!mapped) {
+    return "todo";
+  }
+  return mapped;
+}
+
+export function sanitizeWorkspaceKey(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }

--- a/src/tracker/adapter.test.ts
+++ b/src/tracker/adapter.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { GitHubProjectsAdapter } from "./adapter.js";
+import type { GitHubProjectsClient, ProjectItemNode } from "./github-projects-client.js";
+import { TrackerMalformedPayloadError } from "./github-projects-client.js";
+
+class FakeClient implements GitHubProjectsClient {
+  constructor(
+    private readonly pages: Array<{ items: ProjectItemNode[]; hasNextPage: boolean; endCursor: string | null }>,
+    private readonly idMap: Record<string, ProjectItemNode> = {},
+  ) {}
+
+  async fetchProjectItemsPage(params: {
+    owner: string;
+    projectNumber: number;
+    first: number;
+    after?: string;
+  }): Promise<{ items: ProjectItemNode[]; hasNextPage: boolean; endCursor: string | null }> {
+    const index = params.after ? Number(params.after) : 0;
+    return this.pages[index] ?? { items: [], hasNextPage: false, endCursor: null };
+  }
+
+  async fetchProjectItemsByIds(ids: string[]): Promise<ProjectItemNode[]> {
+    return ids.map((id) => this.idMap[id]).filter((v): v is ProjectItemNode => Boolean(v));
+  }
+}
+
+function item(id: string, number: number, state: string, labels: string[]): ProjectItemNode {
+  return {
+    id,
+    content: {
+      __typename: "Issue",
+      number,
+      title: `Issue ${number}`,
+      body: `Body ${number}`,
+      url: `https://example.com/${number}`,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-02T00:00:00Z",
+      labels: { nodes: labels.map((name) => ({ name })) },
+    },
+    fieldValues: {
+      nodes: [{ __typename: "ProjectV2ItemFieldSingleSelectValue", name: state }],
+    },
+  };
+}
+
+describe("GitHubProjectsAdapter", () => {
+  it("paginates candidate fetch and keeps deterministic normalization", async () => {
+    const client = new FakeClient([
+      { items: [item("A", 101, "Todo", ["Bug", "P1"])], hasNextPage: true, endCursor: "1" },
+      { items: [item("B", 102, "Done", ["Feature"])], hasNextPage: false, endCursor: null },
+    ]);
+
+    const adapter = new GitHubProjectsAdapter({
+      owner: "t0yohei",
+      projectNumber: 1,
+      client,
+      pageSize: 1,
+    });
+
+    const candidates = await adapter.listCandidateItems();
+    assert.equal(candidates.length, 1);
+    assert.deepEqual(candidates[0], {
+      id: "A",
+      identifier: "#101",
+      number: 101,
+      title: "Issue 101",
+      body: "Body 101",
+      description: "Body 101",
+      state: "todo",
+      priority: null,
+      labels: ["bug", "p1"],
+      blocked_by: [],
+      assignees: [],
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+      updatedAt: "2026-01-02T00:00:00Z",
+      url: "https://example.com/101",
+    });
+  });
+
+  it("fetches items by explicit states", async () => {
+    const client = new FakeClient([
+      {
+        items: [item("A", 101, "Todo", []), item("B", 102, "Done", [])],
+        hasNextPage: false,
+        endCursor: null,
+      },
+    ]);
+    const adapter = new GitHubProjectsAdapter({ owner: "o", projectNumber: 1, client });
+
+    const done = await adapter.listItemsByStates(["done"]);
+    assert.equal(done.length, 1);
+    assert.equal(done[0].id, "B");
+  });
+
+  it("fetches state map by ids", async () => {
+    const mapped = {
+      A: item("A", 1, "In Progress", []),
+      B: item("B", 2, "Blocked", []),
+    };
+    const adapter = new GitHubProjectsAdapter({
+      owner: "o",
+      projectNumber: 1,
+      client: new FakeClient([], mapped),
+    });
+
+    const states = await adapter.getStatesByIds(["A", "B"]);
+    assert.deepEqual(states, { A: "in_progress", B: "blocked" });
+  });
+
+  it("throws malformed payload error when issue content is missing", async () => {
+    const bad: ProjectItemNode = {
+      id: "X",
+      content: null,
+      fieldValues: { nodes: [] },
+    };
+    const adapter = new GitHubProjectsAdapter({
+      owner: "o",
+      projectNumber: 1,
+      client: new FakeClient([{ items: [bad], hasNextPage: false, endCursor: null }]),
+    });
+
+    await assert.rejects(() => adapter.listCandidateItems(), TrackerMalformedPayloadError);
+  });
+});

--- a/src/tracker/adapter.ts
+++ b/src/tracker/adapter.ts
@@ -1,14 +1,163 @@
-import type { NormalizedWorkItem } from "../model/work-item.js";
+import type { NormalizedWorkItem, WorkItemState } from "../model/work-item.js";
+import { normalizeState } from "../model/work-item.js";
+import {
+  type GitHubProjectsClient,
+  type ProjectItemNode,
+  TrackerMalformedPayloadError,
+} from "./github-projects-client.js";
 
 export interface TrackerAdapter {
   listEligibleItems(): Promise<NormalizedWorkItem[]>;
+  listCandidateItems(options?: { pageSize?: number; activeStates?: WorkItemState[] }): Promise<NormalizedWorkItem[]>;
+  listItemsByStates(states: WorkItemState[], options?: { pageSize?: number }): Promise<NormalizedWorkItem[]>;
+  getStatesByIds(itemIds: string[]): Promise<Record<string, WorkItemState>>;
   markInProgress(itemId: string): Promise<void>;
   markDone(itemId: string): Promise<void>;
+}
+
+export interface GitHubProjectsAdapterOptions {
+  owner: string;
+  projectNumber: number;
+  client: GitHubProjectsClient;
+  pageSize?: number;
+}
+
+export class GitHubProjectsAdapter implements TrackerAdapter {
+  private readonly owner: string;
+  private readonly projectNumber: number;
+  private readonly client: GitHubProjectsClient;
+  private readonly defaultPageSize: number;
+
+  constructor(options: GitHubProjectsAdapterOptions) {
+    this.owner = options.owner;
+    this.projectNumber = options.projectNumber;
+    this.client = options.client;
+    this.defaultPageSize = options.pageSize ?? 50;
+  }
+
+  async listEligibleItems(): Promise<NormalizedWorkItem[]> {
+    return this.listCandidateItems();
+  }
+
+  async listCandidateItems(options?: {
+    pageSize?: number;
+    activeStates?: WorkItemState[];
+  }): Promise<NormalizedWorkItem[]> {
+    const activeStates = options?.activeStates ?? ["todo", "in_progress", "blocked"];
+    return this.listItemsByStates(activeStates, { pageSize: options?.pageSize });
+  }
+
+  async listItemsByStates(
+    states: WorkItemState[],
+    options?: { pageSize?: number },
+  ): Promise<NormalizedWorkItem[]> {
+    const pageSize = options?.pageSize ?? this.defaultPageSize;
+    const target = new Set(states);
+    const acc: NormalizedWorkItem[] = [];
+
+    let after: string | undefined;
+    while (true) {
+      const page = await this.client.fetchProjectItemsPage({
+        owner: this.owner,
+        projectNumber: this.projectNumber,
+        first: pageSize,
+        after,
+      });
+
+      for (const node of page.items) {
+        const normalized = this.normalizeNode(node);
+        if (target.has(normalized.state)) {
+          acc.push(normalized);
+        }
+      }
+
+      if (!page.hasNextPage || !page.endCursor) break;
+      after = page.endCursor;
+    }
+
+    return acc;
+  }
+
+  async getStatesByIds(itemIds: string[]): Promise<Record<string, WorkItemState>> {
+    const nodes = await this.client.fetchProjectItemsByIds(itemIds);
+    const result: Record<string, WorkItemState> = {};
+    for (const node of nodes) {
+      const state = this.extractState(node);
+      result[node.id] = state;
+    }
+    return result;
+  }
+
+  async markInProgress(_itemId: string): Promise<void> {
+    throw new Error("Use GitHubProjectsWriter for tracker write operations");
+  }
+
+  async markDone(_itemId: string): Promise<void> {
+    throw new Error("Use GitHubProjectsWriter for tracker write operations");
+  }
+
+  private normalizeNode(node: ProjectItemNode): NormalizedWorkItem {
+    if (!node.content || node.content.__typename !== "Issue") {
+      throw new TrackerMalformedPayloadError("Project item does not contain Issue content");
+    }
+
+    const createdAt = node.content.createdAt;
+    const updatedAt = node.content.updatedAt;
+    if (!createdAt || !updatedAt) {
+      throw new TrackerMalformedPayloadError("Project item payload missing timestamps");
+    }
+
+    const labels = (node.content.labels?.nodes ?? [])
+      .map((label) => label?.name?.trim().toLowerCase())
+      .filter((label): label is string => Boolean(label));
+
+    const body = node.content.body ?? "";
+
+    return {
+      id: node.id,
+      identifier: `#${node.content.number}`,
+      number: node.content.number,
+      title: node.content.title,
+      body,
+      description: body,
+      state: this.extractState(node),
+      priority: null,
+      labels,
+      blocked_by: [],
+      assignees: [],
+      created_at: createdAt,
+      updated_at: updatedAt,
+      updatedAt: updatedAt,
+      url: node.content.url,
+    };
+  }
+
+  private extractState(node: ProjectItemNode): WorkItemState {
+    const singleSelect =
+      node.fieldValues?.nodes?.find((n) => n?.__typename === "ProjectV2ItemFieldSingleSelectValue") ?? null;
+
+    if (singleSelect && "name" in singleSelect && typeof singleSelect.name === "string") {
+      return normalizeState(singleSelect.name);
+    }
+    return "todo";
+  }
 }
 
 export class GitHubProjectsAdapterPlaceholder implements TrackerAdapter {
   async listEligibleItems(): Promise<NormalizedWorkItem[]> {
     return [];
+  }
+
+  async listCandidateItems(): Promise<NormalizedWorkItem[]> {
+    return [];
+  }
+
+  async listItemsByStates(): Promise<NormalizedWorkItem[]> {
+    return [];
+  }
+
+  async getStatesByIds(): Promise<Record<string, WorkItemState>> {
+    return {};
   }
 
   async markInProgress(_itemId: string): Promise<void> {

--- a/src/tracker/github-projects-client.ts
+++ b/src/tracker/github-projects-client.ts
@@ -1,0 +1,239 @@
+import { GraphQLClient, GraphQLError } from "./graphql-client.js";
+
+export class TrackerTransportError extends Error {
+  constructor(message: string, public readonly causeError?: unknown) {
+    super(message);
+    this.name = "TrackerTransportError";
+  }
+}
+
+export class TrackerStatusError extends Error {
+  constructor(public readonly status: number, message?: string) {
+    super(message ?? `Tracker request failed with status ${status}`);
+    this.name = "TrackerStatusError";
+  }
+}
+
+export class TrackerGraphQLError extends Error {
+  constructor(message: string, public readonly errors: Array<{ message: string }>) {
+    super(message);
+    this.name = "TrackerGraphQLError";
+  }
+}
+
+export class TrackerMalformedPayloadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TrackerMalformedPayloadError";
+  }
+}
+
+export interface ProjectItemNode {
+  id: string;
+  content: {
+    __typename: "Issue" | "PullRequest";
+    number: number;
+    title: string;
+    body?: string;
+    url?: string;
+    labels?: { nodes?: Array<{ name: string | null } | null> | null };
+    createdAt?: string;
+    updatedAt?: string;
+  } | null;
+  fieldValues?: {
+    nodes?: Array<
+      | { __typename: "ProjectV2ItemFieldSingleSelectValue"; name?: string | null }
+      | { __typename: string }
+      | null
+    > | null;
+  };
+}
+
+export interface ProjectItemsPage {
+  items: ProjectItemNode[];
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
+
+export interface GitHubProjectsClient {
+  fetchProjectItemsPage(params: {
+    owner: string;
+    projectNumber: number;
+    first: number;
+    after?: string;
+  }): Promise<ProjectItemsPage>;
+  fetchProjectItemsByIds(ids: string[]): Promise<ProjectItemNode[]>;
+}
+
+interface ProjectItemsPageQuery {
+  user?: {
+    projectV2?: {
+      items?: {
+        pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+        nodes?: Array<ProjectItemNode | null>;
+      };
+    };
+  };
+  organization?: {
+    projectV2?: {
+      items?: {
+        pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+        nodes?: Array<ProjectItemNode | null>;
+      };
+    };
+  };
+}
+
+interface NodesByIdsQuery {
+  nodes?: Array<ProjectItemNode | null>;
+}
+
+export class GitHubProjectsGraphQLClient implements GitHubProjectsClient {
+  constructor(private readonly client: GraphQLClient) {}
+
+  async fetchProjectItemsPage(params: {
+    owner: string;
+    projectNumber: number;
+    first: number;
+    after?: string;
+  }): Promise<ProjectItemsPage> {
+    const query = `
+      query ProjectItems($owner: String!, $number: Int!, $first: Int!, $after: String) {
+        user(login: $owner) {
+          projectV2(number: $number) {
+            items(first: $first, after: $after) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                id
+                content {
+                  __typename
+                  ... on Issue {
+                    number
+                    title
+                    body
+                    url
+                    createdAt
+                    updatedAt
+                    labels(first: 20) { nodes { name } }
+                  }
+                }
+                fieldValues(first: 20) {
+                  nodes {
+                    __typename
+                    ... on ProjectV2ItemFieldSingleSelectValue {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        organization(login: $owner) {
+          projectV2(number: $number) {
+            items(first: $first, after: $after) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                id
+                content {
+                  __typename
+                  ... on Issue {
+                    number
+                    title
+                    body
+                    url
+                    createdAt
+                    updatedAt
+                    labels(first: 20) { nodes { name } }
+                  }
+                }
+                fieldValues(first: 20) {
+                  nodes {
+                    __typename
+                    ... on ProjectV2ItemFieldSingleSelectValue {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    const data = await this.safeQuery<ProjectItemsPageQuery>(query, {
+      owner: params.owner,
+      number: params.projectNumber,
+      first: params.first,
+      after: params.after ?? null,
+    });
+
+    const connection = data.user?.projectV2?.items ?? data.organization?.projectV2?.items;
+    if (!connection) {
+      throw new TrackerMalformedPayloadError("Project items connection missing in GraphQL response");
+    }
+
+    return {
+      items: (connection.nodes ?? []).filter((n): n is ProjectItemNode => Boolean(n)),
+      hasNextPage: Boolean(connection.pageInfo?.hasNextPage),
+      endCursor: connection.pageInfo?.endCursor ?? null,
+    };
+  }
+
+  async fetchProjectItemsByIds(ids: string[]): Promise<ProjectItemNode[]> {
+    if (ids.length === 0) return [];
+
+    const query = `
+      query ProjectItemsByIds($ids: [ID!]!) {
+        nodes(ids: $ids) {
+          ... on ProjectV2Item {
+            id
+            content {
+              __typename
+              ... on Issue {
+                number
+                title
+                body
+                url
+                createdAt
+                updatedAt
+                labels(first: 20) { nodes { name } }
+              }
+            }
+            fieldValues(first: 20) {
+              nodes {
+                __typename
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    const data = await this.safeQuery<NodesByIdsQuery>(query, { ids });
+    return (data.nodes ?? []).filter((n): n is ProjectItemNode => Boolean(n));
+  }
+
+  private async safeQuery<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+    try {
+      return await this.client.query<T>(query, variables);
+    } catch (error) {
+      if (error instanceof GraphQLError) {
+        const m = error.message.toLowerCase();
+        if (m.includes("failed:") || m.includes("status")) {
+          const status = Number(error.message.match(/(\d{3})/)?.[1] ?? 0);
+          throw new TrackerStatusError(status || 500, error.message);
+        }
+        if (error.errors.length > 0) {
+          throw new TrackerGraphQLError(error.message, error.errors);
+        }
+        throw new TrackerMalformedPayloadError(error.message);
+      }
+      throw new TrackerTransportError("Failed to communicate with tracker backend", error);
+    }
+  }
+}


### PR DESCRIPTION
Closes #46

## Changes
- Implemented `GitHubProjectsAdapter` and added three operations required by orchestration
  - candidate fetch (for active states)
  - fetch by states (for startup cleanup)
  - fetch states by item IDs (for reconciliation)
- Added GitHub Projects GraphQL client layer `GitHubProjectsGraphQLClient`
  - Classifies GraphQL/HTTP/payload anomalies into explicit error types
- Expanded normalized model
  - Added `identifier`, `description`, `priority`, `blocked_by`, `created_at`, `updated_at`, etc.
  - Implemented deterministic normalization for state/label values
- Added tests (`src/tracker/adapter.test.ts`)
  - pagination
  - state filters
  - ID-based state fetch
  - malformed payload error validation

## Test Result
- `npm run lint` ✅
- `npm run build` ✅
- `npm test` ✅ (51 tests passed)

## Known Risks
- Fallback status inference from GraphQL error wording is fragile against future wording changes
- Current normalization scope is issue-based (PR content is out of scope)
