### PR TITLE
feat: [SPEC parity] active-run reconciliation behaviors (issue #49)

### DIFF
--- a/src/orchestrator/runtime.test.ts
+++ b/src/orchestrator/runtime.test.ts
@@ -6,8 +6,17 @@ import type { NormalizedWorkItem, WorkItemState } from '../model/work-item.js';
 import { PollingRuntime } from './runtime.js';
 
 class FakeLogger implements Logger {
-  info(): void {}
-  warn(): void {}
+  public readonly infoLogs: Array<{ message: string; data?: Record<string, unknown> }> = [];
+  public readonly warnLogs: Array<{ message: string; data?: Record<string, unknown> }> = [];
+
+  info(message: string, data?: Record<string, unknown>): void {
+    this.infoLogs.push({ message, data });
+  }
+
+  warn(message: string, data?: Record<string, unknown>): void {
+    this.warnLogs.push({ message, data });
+  }
+
   error(): void {}
 }
 
@@ -17,6 +26,7 @@ class FakeTracker {
   public markInProgressCalls: string[] = [];
   public markDoneCalls: string[] = [];
   public failMarkInProgressFor = new Set<string>();
+  public failGetStatesByIds = false;
 
   async listEligibleItems(): Promise<NormalizedWorkItem[]> {
     return this.items;
@@ -31,6 +41,10 @@ class FakeTracker {
   }
 
   async getStatesByIds(itemIds: string[]): Promise<Record<string, WorkItemState>> {
+    if (this.failGetStatesByIds) {
+      throw new Error('state refresh failed');
+    }
+
     const result: Record<string, WorkItemState> = {};
     for (const id of itemIds) {
       const state = this.states[id];
@@ -151,5 +165,66 @@ describe('PollingRuntime state machine', () => {
     await runtime.tick();
     assert.equal(tracker.markInProgressCalls.length, 2);
     assert.deepEqual(runtime.snapshot().running, ['A']);
+  });
+
+  it('does not crash tick when state refresh fails and retries on next tick', async () => {
+    const tracker = new FakeTracker();
+    tracker.items = [item('A', 101)];
+    tracker.states.A = 'in_progress';
+    const logger = new FakeLogger();
+
+    const runtime = new PollingRuntime(tracker, workflow, logger);
+
+    await runtime.tick();
+    tracker.failGetStatesByIds = true;
+    await runtime.tick();
+
+    assert.equal(runtime.snapshot().running.length, 1);
+    assert.ok(
+      logger.warnLogs.some((log) => log.message === 'runtime.transition.reconcile_state_refresh_failed'),
+    );
+
+    tracker.failGetStatesByIds = false;
+    await runtime.tick();
+    assert.equal(runtime.snapshot().running.length, 1);
+  });
+
+  it('disables stall detection when stallTimeoutMs is zero or less', async () => {
+    let now = 10_000;
+    const tracker = new FakeTracker();
+    tracker.items = [item('A', 101)];
+    tracker.states.A = 'in_progress';
+
+    const runtime = new PollingRuntime(tracker, workflow, new FakeLogger(), {
+      now: () => now,
+      stallTimeoutMs: 0,
+    });
+
+    await runtime.tick();
+    now += 60 * 60 * 1000;
+    await runtime.tick();
+
+    assert.deepEqual(runtime.snapshot().running, ['A']);
+    assert.equal(runtime.snapshot().retryAttempts.A, undefined);
+  });
+
+  it('stops non-active running item without scheduling retry', async () => {
+    const tracker = new FakeTracker();
+    tracker.items = [item('A', 101)];
+    tracker.states.A = 'in_progress';
+    const logger = new FakeLogger();
+
+    const runtime = new PollingRuntime(tracker, workflow, logger);
+
+    await runtime.tick();
+    tracker.states.A = 'todo';
+    tracker.items = [];
+    await runtime.tick();
+
+    assert.equal(runtime.snapshot().running.length, 0);
+    assert.equal(runtime.snapshot().retryAttempts.A, undefined);
+    assert.ok(
+      logger.infoLogs.some((log) => log.message === 'runtime.transition.reconcile_stopped_non_active'),
+    );
   });
 });

--- a/src/orchestrator/runtime.ts
+++ b/src/orchestrator/runtime.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '../logging/logger.js';
-import type { NormalizedWorkItem } from '../model/work-item.js';
+import type { NormalizedWorkItem, WorkItemState } from '../model/work-item.js';
 import type { TrackerAdapter } from '../tracker/adapter.js';
 import type { WorkflowContract } from '../workflow/contract.js';
 
@@ -161,16 +161,18 @@ export class PollingRuntime implements OrchestratorRuntime {
 
   private async reconcile(): Promise<void> {
     const now = this.now();
-    const runningIds = [...this.running.keys()];
-    if (runningIds.length === 0) {
+    if (this.running.size === 0) {
       return;
     }
 
-    for (const [itemId, entry] of this.running.entries()) {
-      if (now - entry.lastEventAt > this.stallTimeoutMs) {
-        this.running.delete(itemId);
-        this.claimed.delete(itemId);
-        this.scheduleRetry(entry.item, 'failure', 'stalled');
+    if (this.stallTimeoutMs > 0) {
+      for (const [itemId, entry] of this.running.entries()) {
+        const lastActivityAt = entry.lastEventAt || entry.startedAt;
+        if (now - lastActivityAt > this.stallTimeoutMs) {
+          this.running.delete(itemId);
+          this.claimed.delete(itemId);
+          this.scheduleRetry(entry.item, 'failure', 'stalled');
+        }
       }
     }
 
@@ -179,7 +181,18 @@ export class PollingRuntime implements OrchestratorRuntime {
       return;
     }
 
-    const trackerStates = await this.tracker.getStatesByIds(activeIds);
+    let trackerStates: Record<string, WorkItemState>;
+    try {
+      trackerStates = await this.tracker.getStatesByIds(activeIds);
+    } catch (err) {
+      this.logger.warn('runtime.transition.reconcile_state_refresh_failed', {
+        issue_id: undefined,
+        issue_identifier: undefined,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+
     for (const itemId of activeIds) {
       const entry = this.running.get(itemId);
       if (!entry) continue;
@@ -207,7 +220,12 @@ export class PollingRuntime implements OrchestratorRuntime {
       if (state !== 'in_progress') {
         this.running.delete(itemId);
         this.claimed.delete(itemId);
-        this.scheduleRetry(entry.item, 'failure', `state_${state}`);
+        this.clearRetry(itemId);
+        this.logger.info('runtime.transition.reconcile_stopped_non_active', {
+          issue_id: entry.item.id,
+          issue_identifier: entry.item.identifier,
+          state,
+        });
       }
     }
   }


### PR DESCRIPTION
## Linked Issue
- Closes #49

## Changes
- Strengthened `PollingRuntime.reconcile`; on tracker state-refresh failure, emit warning and continue to next tick without failing whole tick
- Disabled stall detection when `stallTimeoutMs <= 0` (SPEC-compatible behavior)
- Stall timing now prefers `lastEventAt`, falling back to `startedAt` when missing
- Refined post-refresh transitions:
  - `done`: release running/claimed and move to completed
  - `in_progress`: continue
  - non-active & non-terminal: stop running and release without retry (equivalent to no cleanup)

## Test Result
- `npm run lint` ✅
- `npm test -- --runInBand` ✅ (57 tests passed)

## Known Risks
- “Stop-only (no retry)” for non-active items depends on tracker-side eligibility logic, so items may become candidates again on a later tick
- Cleanup is not yet integrated in current runtime, so physical workspace deletion still needs another layer
