### PR TITLE
feat: [SPEC parity] workspace manager safety invariants (issue #50)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export * from './tracker/github-projects-client.js';
 export * from './tracker/github-projects-writer.js';
 export * from './agent/codex-app-server.js';
 export * from './workspace/hooks.js';
+export * from './workspace/manager.js';
 export * from './orchestrator/reconciler.js';
 export * from './workflow/hot-reload.js';
 export * from './prompt/template.js';

--- a/src/model/work-item.ts
+++ b/src/model/work-item.ts
@@ -42,9 +42,5 @@ export function normalizeState(value: string): WorkItemState {
 }
 
 export function sanitizeWorkspaceKey(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9._-]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+  return value.trim().replace(/[^A-Za-z0-9._-]/g, '_');
 }

--- a/src/workspace/manager.test.ts
+++ b/src/workspace/manager.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { HookRunner } from './hooks.js';
+import { WorkspaceManager, WorkspaceSafetyError } from './manager.js';
+
+function createHookRunner(exitCode: number, calls: string[]): HookRunner {
+  return new HookRunner({
+    hooks: {
+      after_create: 'echo create',
+      before_run: 'echo run',
+      after_run: 'echo post',
+      before_remove: 'echo remove',
+    },
+    logger: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+    exec: async (_cmd, args, opts) => {
+      calls.push(`${args.join(' ')}@${opts.cwd}`);
+      return {
+        stdout: '',
+        stderr: exitCode === 0 ? '' : 'failed',
+        exitCode,
+      };
+    },
+  });
+}
+
+test('toWorkspaceKey keeps [A-Za-z0-9._-] and replaces others with _', () => {
+  const manager = new WorkspaceManager({ workspaceRoot: '/tmp/workspaces' });
+  const key = manager.toWorkspaceKey(' Issue #50: 安全/../Path ');
+  assert.equal(key, 'Issue__50_____.._Path');
+});
+
+test('prepareWorkspace creates then reuses existing workspace', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'workspace-manager-'));
+  const manager = new WorkspaceManager({ workspaceRoot: root });
+
+  try {
+    const first = await manager.prepareWorkspace('issue-50');
+    const second = await manager.prepareWorkspace('issue-50');
+
+    assert.equal(first.created, true);
+    assert.equal(second.created, false);
+    assert.equal(first.path, second.path);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('assertWorkspacePath rejects traversal outside root', () => {
+  const manager = new WorkspaceManager({ workspaceRoot: '/tmp/ws-root' });
+  assert.throws(() => manager.assertWorkspacePath('/tmp/elsewhere/escape'), WorkspaceSafetyError);
+});
+
+test('assertWorkerCwd enforces exact computed workspace path', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'workspace-manager-'));
+  const manager = new WorkspaceManager({ workspaceRoot: root });
+
+  try {
+    const prepared = await manager.prepareWorkspace('issue-50');
+    const expected = manager.assertWorkerCwd('issue-50', prepared.path);
+    assert.equal(expected, prepared.path);
+
+    assert.throws(() => manager.assertWorkerCwd('issue-50', root), WorkspaceSafetyError);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('cleanupTerminalStateWorkspaces removes done/blocked only', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'workspace-manager-'));
+  const manager = new WorkspaceManager({ workspaceRoot: root });
+
+  try {
+    const done = await manager.prepareWorkspace('done-item');
+    const blocked = await manager.prepareWorkspace('blocked-item');
+    const todo = await manager.prepareWorkspace('todo-item');
+
+    const cleaned = await manager.cleanupTerminalStateWorkspaces([
+      { workspacePath: done.path, state: 'done' },
+      { workspacePath: blocked.path, state: 'blocked' },
+      { workspacePath: todo.path, state: 'todo' },
+    ]);
+
+    assert.equal(cleaned, 2);
+
+    const doneRecreated = await manager.prepareWorkspace('done-item');
+    const todoReused = await manager.prepareWorkspace('todo-item');
+    assert.equal(doneRecreated.created, true);
+    assert.equal(todoReused.created, false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('after_create and before_run failures are fatal, after_run and before_remove are non-fatal', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'workspace-manager-'));
+  const calls: string[] = [];
+  const failingHooks = createHookRunner(1, calls);
+  const manager = new WorkspaceManager({ workspaceRoot: root, hooks: failingHooks });
+
+  try {
+    await assert.rejects(() => manager.prepareWorkspace('fatal-after-create'));
+
+    const plain = new WorkspaceManager({ workspaceRoot: root });
+    const prepared = await plain.prepareWorkspace('existing-for-before-run');
+    await assert.rejects(() => manager.beforeRun(prepared.path));
+
+    await manager.afterRun(prepared.path);
+    await manager.cleanupWorkspace(prepared.path);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+
+  assert.ok(calls.some((call) => call.includes('echo create')));
+  assert.ok(calls.some((call) => call.includes('echo run')));
+  assert.ok(calls.some((call) => call.includes('echo post')));
+  assert.ok(calls.some((call) => call.includes('echo remove')));
+});

--- a/src/workspace/manager.ts
+++ b/src/workspace/manager.ts
@@ -1,0 +1,123 @@
+import { mkdir, realpath, rm } from 'node:fs/promises';
+import path from 'node:path';
+
+import { sanitizeWorkspaceKey } from '../model/work-item.js';
+import { HookFailureError, HookRunner } from './hooks.js';
+
+export interface WorkspaceManagerOptions {
+  workspaceRoot: string;
+  hooks?: HookRunner;
+}
+
+export interface PreparedWorkspace {
+  key: string;
+  path: string;
+  created: boolean;
+}
+
+export class WorkspaceSafetyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WorkspaceSafetyError';
+  }
+}
+
+export class WorkspaceManager {
+  private readonly workspaceRoot: string;
+  private readonly hooks?: HookRunner;
+
+  constructor(options: WorkspaceManagerOptions) {
+    this.workspaceRoot = path.resolve(options.workspaceRoot);
+    this.hooks = options.hooks;
+  }
+
+  async prepareWorkspace(rawKey: string): Promise<PreparedWorkspace> {
+    const key = this.toWorkspaceKey(rawKey);
+    const workspacePath = this.resolveWorkspacePath(key);
+
+    let created = false;
+    try {
+      await realpath(workspacePath);
+    } catch {
+      await mkdir(workspacePath, { recursive: true });
+      created = true;
+    }
+
+    if (created && this.hooks) {
+      const hookResult = await this.hooks.afterCreate(workspacePath);
+      if (!hookResult.success) {
+        await rm(workspacePath, { recursive: true, force: true });
+        throw new HookFailureError(hookResult);
+      }
+    }
+
+    return { key, path: workspacePath, created };
+  }
+
+  async beforeRun(workspacePath: string): Promise<void> {
+    this.assertWorkspacePath(workspacePath);
+    if (!this.hooks) return;
+    const result = await this.hooks.beforeRun(path.resolve(workspacePath));
+    if (!result.success) {
+      throw new HookFailureError(result);
+    }
+  }
+
+  async afterRun(workspacePath: string): Promise<void> {
+    this.assertWorkspacePath(workspacePath);
+    await this.hooks?.afterRun(path.resolve(workspacePath));
+  }
+
+  async cleanupWorkspace(workspacePath: string): Promise<void> {
+    this.assertWorkspacePath(workspacePath);
+    const abs = path.resolve(workspacePath);
+    await this.hooks?.beforeRemove(abs);
+    await rm(abs, { recursive: true, force: true });
+  }
+
+  async cleanupTerminalStateWorkspaces(entries: Array<{ workspacePath: string; state: string }>): Promise<number> {
+    const terminal = new Set(['done', 'blocked']);
+    let cleaned = 0;
+    for (const entry of entries) {
+      if (!terminal.has(entry.state)) continue;
+      this.assertWorkspacePath(entry.workspacePath);
+      await this.cleanupWorkspace(entry.workspacePath);
+      cleaned += 1;
+    }
+    return cleaned;
+  }
+
+  assertWorkerCwd(rawKey: string, cwd: string): string {
+    const expected = this.resolveWorkspacePath(this.toWorkspaceKey(rawKey));
+    const actual = path.resolve(cwd);
+    if (actual !== expected) {
+      throw new WorkspaceSafetyError(`worker cwd mismatch: expected ${expected}, got ${actual}`);
+    }
+    return expected;
+  }
+
+  toWorkspaceKey(rawKey: string): string {
+    const key = sanitizeWorkspaceKey(rawKey);
+    if (!key) {
+      throw new WorkspaceSafetyError('workspace key became empty after sanitization');
+    }
+    return key;
+  }
+
+  resolveWorkspacePath(workspaceKey: string): string {
+    const workspacePath = path.resolve(this.workspaceRoot, workspaceKey);
+    this.assertWorkspacePath(workspacePath);
+    return workspacePath;
+  }
+
+  assertWorkspacePath(candidatePath: string): void {
+    const abs = path.resolve(candidatePath);
+    const rel = path.relative(this.workspaceRoot, abs);
+    if (rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel))) {
+      return;
+    }
+    throw new WorkspaceSafetyError(
+      `workspace path escapes root: root=${this.workspaceRoot} candidate=${abs}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add WorkspaceManager to centralize workspace safety checks and lifecycle operations
- enforce deterministic key sanitization ([A-Za-z0-9._-] keep, others _) and reject empty keys
- enforce path containment under workspace root + worker cwd exact-match guard
- add terminal-state startup cleanup (done/blocked) and workspace create/reuse flow
- make hook lifecycle semantics explicit in manager flow (after_create/before_run fatal, after_run/before_remove non-fatal)

## Test Results
- npm test ✅
- npm run lint ✅

## Known Risks
- cleanupTerminalStateWorkspaces currently treats blocked as terminal by policy; if product semantics change, this set must be adjusted
- new manager is introduced and exported, but not yet fully wired into orchestrator boot/runtime paths

Closes #50
