### PR TITLE
feat: [SPEC parity] align Codex app-server handshake + thread semantics (issue #51)

### DIFF
--- a/src/agent/codex-app-server.test.ts
+++ b/src/agent/codex-app-server.test.ts
@@ -34,7 +34,7 @@ class FakeChildProcess extends EventEmitter {
   }
 }
 
-test('spawns codex app-server with workspace cwd and sends thread/turn start', async () => {
+test('spawns codex app-server with deterministic initialize -> thread/turn order', async () => {
   const fake = new FakeChildProcess();
   const spawnCalls: Array<{ command: string; args: string[]; cwd: string }> = [];
 
@@ -45,6 +45,7 @@ test('spawns codex app-server with workspace cwd and sends thread/turn start', a
     spawn: (command, args, options) => {
       spawnCalls.push({ command, args, cwd: options.cwd });
       queueMicrotask(() => {
+        fake.emitStdoutJson({ method: 'initialized' });
         fake.emitStdoutJson({
           params: {
             session_id: 's1',
@@ -75,14 +76,16 @@ test('spawns codex app-server with workspace cwd and sends thread/turn start', a
   assert.equal(result.state.turnId, 'turn-1');
   assert.equal(result.state.usage.totalTokens, 13);
 
-  const payload = fake.writes.join('');
-  assert.match(payload, /"method":"thread.start"/);
-  assert.match(payload, /"method":"turn.start"/);
-  assert.match(payload, /"message":"hello codex"/);
+  const writes = fake.writes.map((w) => JSON.parse(w.trim()));
+  assert.equal(writes[0].method, 'initialize');
+  assert.equal(writes[1].method, 'thread.start');
+  assert.equal(writes[2].method, 'turn.start');
+  assert.equal(writes[2].params.message, 'hello codex');
 });
 
-test('continues multi-turn when active issue is returned', async () => {
+test('continues multi-turn on same thread and uses continuation guidance', async () => {
   const fake = new FakeChildProcess();
+  let initializedSent = false;
   let firstTurnEventSent = false;
   let secondTurnEventSent = false;
 
@@ -94,13 +97,18 @@ test('continues multi-turn when active issue is returned', async () => {
     spawn: () => {
       const timer = setInterval(() => {
         const payload = fake.writes.join('');
+        if (!initializedSent && payload.includes('"method":"initialize"')) {
+          initializedSent = true;
+          fake.emitStdoutJson({ method: 'initialized' });
+          fake.emitStdoutJson({ params: { thread_id: 'shared-thread' } });
+        }
         if (!firstTurnEventSent && payload.includes('"turn":1')) {
           firstTurnEventSent = true;
           fake.emitStdoutJson({ params: { turn: { completed: true, active_issue: true } } });
         }
         if (!secondTurnEventSent && payload.includes('"turn":2')) {
           secondTurnEventSent = true;
-          fake.emitStdoutJson({ params: { turn: { completed: true, active_issue: false } } });
+          fake.emitStdoutJson({ params: { turn_id: 'turn-2', turn: { completed: true, active_issue: false } } });
           clearInterval(timer);
         }
       }, 1);
@@ -118,11 +126,45 @@ test('continues multi-turn when active issue is returned', async () => {
   assert.ok(result.state.turnsStarted >= 2);
   assert.ok(result.state.turnsCompleted >= 2);
 
-  const payload = fake.writes.join('');
-  assert.match(payload, /"message":"first prompt"/);
-  assert.match(payload, /"message":"continue please"/);
+  const writes = fake.writes.map((w) => JSON.parse(w.trim()));
+  const turnMessages = writes.filter((w) => w.method === 'turn.start').map((w) => w.params.message);
+  assert.deepEqual(turnMessages.slice(0, 2), ['first prompt', 'continue please']);
+
+  const threadStart = writes.find((w) => w.method === 'thread.start');
+  assert.equal(threadStart?.params.prompt, 'first prompt');
+
+  const secondTurn = writes.find((w) => w.method === 'turn.start' && w.params.turn === 2);
+  assert.equal(secondTurn?.params.thread_id, 'shared-thread');
+  assert.equal(initializedSent, true);
   assert.equal(firstTurnEventSent, true);
   assert.equal(secondTurnEventSent, true);
+});
+
+test('derives session id from thread id when session_id is absent', async () => {
+  const fake = new FakeChildProcess();
+  const client = new CodexAppServerClient({
+    cwd: '/tmp/workspace',
+    readTimeoutMs: 10,
+    stallTimeoutMs: 500,
+    spawn: () => {
+      queueMicrotask(() => {
+        fake.emitStdoutJson({ method: 'initialized' });
+        fake.emitStdoutJson({
+          params: {
+            thread_id: 't-derived',
+            turn_id: 'turn-1',
+            turn: { completed: true, active_issue: false },
+          },
+        });
+      });
+      return fake;
+    },
+  });
+
+  const result = await client.run({ renderedPrompt: 'hello' });
+  assert.equal(result.status, 'completed');
+  assert.equal(result.state.sessionId, 'thread:t-derived');
+  assert.equal(result.state.threadId, 't-derived');
 });
 
 test('detects stall and terminates the subprocess', async () => {

--- a/src/agent/codex-app-server.ts
+++ b/src/agent/codex-app-server.ts
@@ -124,6 +124,7 @@ export class CodexAppServerClient {
     let completed = false;
     let activeIssue = false;
     let errorMessage: string | undefined;
+    let initialized = false;
 
     child.stdout?.on('data', (chunk: Buffer | string) => {
       latestEventAt = Date.now();
@@ -135,6 +136,17 @@ export class CodexAppServerClient {
         if (line !== '') {
           this.handleEventLine(line, (event) => {
             this.applyEvent(event);
+
+            const initializedFlag = readBoolean(event, [
+              'params.initialized',
+              'initialized',
+              'params.ready',
+              'ready',
+            ]);
+            if (initializedFlag === true || this.isInitializedEvent(event)) {
+              initialized = true;
+            }
+
             const completedFlag = readBoolean(event, [
               'params.turn.completed',
               'params.completed',
@@ -184,13 +196,44 @@ export class CodexAppServerClient {
       throw new Error('codex app-server stdin is not available');
     }
 
-    const threadStartMessage = JSON.stringify({
-      method: 'thread.start',
-      params: {
-        prompt: params.renderedPrompt,
-      },
+    child.stdin.write(`${JSON.stringify({ method: 'initialize', params: {} })}\n`);
+
+    const initOutcome = await waitForUntil({
+      isDone: () => initialized,
+      hasError: () => errorMessage,
+      latestEventAt: () => latestEventAt,
+      turnTimeoutMs: this.turnTimeoutMs,
+      readTimeoutMs: this.readTimeoutMs,
+      stallTimeoutMs: this.stallTimeoutMs,
     });
-    child.stdin.write(`${threadStartMessage}\n`);
+
+    if (initOutcome === 'stalled') {
+      child.kill('SIGTERM');
+      return { status: 'stalled', activeIssue: false, state: this.snapshotState() };
+    }
+    if (initOutcome === 'timeout') {
+      child.kill('SIGTERM');
+      return { status: 'timeout', activeIssue: false, state: this.snapshotState() };
+    }
+    if (errorMessage) {
+      const status = /rate\s*limit/i.test(errorMessage) ? 'rate_limited' : 'error';
+      child.kill('SIGTERM');
+      return {
+        status,
+        activeIssue: false,
+        state: this.snapshotState(),
+        errorMessage,
+      };
+    }
+
+    const threadStartParams: Record<string, string> = {
+      prompt: params.renderedPrompt,
+    };
+    if (this.state.threadId) {
+      threadStartParams.thread_id = this.state.threadId;
+    }
+
+    child.stdin.write(`${JSON.stringify({ method: 'thread.start', params: threadStartParams })}\n`);
 
     for (let turn = 1; turn <= this.maxTurns; turn += 1) {
       const message =
@@ -198,18 +241,23 @@ export class CodexAppServerClient {
           ? params.renderedPrompt
           : (params.continuationGuidance ?? 'Continue from the active issue and finish the task.');
 
+      const turnParams: Record<string, string | number> = {
+        message,
+        turn,
+      };
+      if (this.state.threadId) {
+        turnParams.thread_id = this.state.threadId;
+      }
+
       const turnStartMessage = JSON.stringify({
         method: 'turn.start',
-        params: {
-          message,
-          turn,
-        },
+        params: turnParams,
       });
       this.state.turnsStarted += 1;
       child.stdin.write(`${turnStartMessage}\n`);
 
-      const turnOutcome = await waitForTurnOutcome({
-        isCompleted: () => completed,
+      const turnOutcome = await waitForUntil({
+        isDone: () => completed,
         hasError: () => errorMessage,
         latestEventAt: () => latestEventAt,
         turnTimeoutMs: this.turnTimeoutMs,
@@ -257,6 +305,11 @@ export class CodexAppServerClient {
     };
   }
 
+  private isInitializedEvent(event: JsonRpcEvent): boolean {
+    const method = readString(event, ['method', 'event', 'type']);
+    return method === 'initialized' || method === 'initialize.done';
+  }
+
   private handleEventLine(line: string, onEvent: (event: JsonRpcEvent) => void): void {
     try {
       const parsed = JSON.parse(line) as JsonRpcEvent;
@@ -272,6 +325,10 @@ export class CodexAppServerClient {
     this.state.threadId =
       readString(event, ['params.thread_id', 'thread_id']) ?? this.state.threadId;
     this.state.turnId = readString(event, ['params.turn_id', 'turn_id']) ?? this.state.turnId;
+
+    if (!this.state.sessionId && this.state.threadId) {
+      this.state.sessionId = `thread:${this.state.threadId}`;
+    }
 
     const inputTokens = readNumber(event, [
       'params.usage.input_tokens',
@@ -321,8 +378,8 @@ export class CodexAppServerClient {
   }
 }
 
-async function waitForTurnOutcome(params: {
-  isCompleted: () => boolean;
+async function waitForUntil(params: {
+  isDone: () => boolean;
   hasError: () => string | undefined;
   latestEventAt: () => number;
   turnTimeoutMs: number;
@@ -334,7 +391,7 @@ async function waitForTurnOutcome(params: {
     if (params.hasError()) {
       return 'error';
     }
-    if (params.isCompleted()) {
+    if (params.isDone()) {
       return 'completed';
     }
 


### PR DESCRIPTION
## Linked Issue
- Closes #51

## Changes
- Standardized Codex app-server handshake order to `initialize -> initialized -> thread.start -> turn.start`
- Added explicit wait for `initialized` to prevent starting turns before initialization completes
- On multi-turn continuation, explicitly pass the same `thread_id` to `turn.start` to guarantee thread reuse
- If `session_id` is missing, derive `sessionId=thread:<thread_id>` to avoid dropping observability metadata
- Kept stdout(JSON-RPC events) / stderr(diagnostic text) handling and added tests for handshake + continuation paths

## Test Result
- `npm run lint` ✅
- `npm run build` ✅
- `npm test` ✅ (64 tests passed)

## Known Risks
- `initialized` detection currently accepts `method=initialized|initialize.done` and `initialized/ready=true`; if protocol event names change later, detection logic must be updated
- `thread.start` still passes `prompt`; adjustments may be required if server-side contract changes
