### PR TITLE
feat: [SPEC parity] dispatch preflight validation + dynamic config apply (issue #52)

### DIFF
--- a/src/orchestrator/runtime.test.ts
+++ b/src/orchestrator/runtime.test.ts
@@ -27,6 +27,7 @@ class FakeTracker {
   public markDoneCalls: string[] = [];
   public failMarkInProgressFor = new Set<string>();
   public failGetStatesByIds = false;
+  public getStatesByIdsCalls = 0;
 
   async listEligibleItems(): Promise<NormalizedWorkItem[]> {
     return this.items;
@@ -41,6 +42,7 @@ class FakeTracker {
   }
 
   async getStatesByIds(itemIds: string[]): Promise<Record<string, WorkItemState>> {
+    this.getStatesByIdsCalls += 1;
     if (this.failGetStatesByIds) {
       throw new Error('state refresh failed');
     }
@@ -89,13 +91,18 @@ const workflow = {
   agent: { command: 'codex' },
 };
 
+const baseRuntimeOptions = {
+  env: { GITHUB_TOKEN: 'token' },
+  commandExists: () => true,
+};
+
 describe('PollingRuntime state machine', () => {
   it('prevents duplicate dispatch across ticks for already running item', async () => {
     const tracker = new FakeTracker();
     tracker.items = [item('A', 101)];
     tracker.states.A = 'in_progress';
 
-    const runtime = new PollingRuntime(tracker, workflow, new FakeLogger());
+    const runtime = new PollingRuntime(tracker, workflow, new FakeLogger(), baseRuntimeOptions);
 
     await runtime.tick();
     await runtime.tick();
@@ -111,6 +118,7 @@ describe('PollingRuntime state machine', () => {
     tracker.failMarkInProgressFor.add('A');
 
     const runtime = new PollingRuntime(tracker, workflow, new FakeLogger(), {
+      ...baseRuntimeOptions,
       now: () => now,
       continuationRetryDelayMs: 50,
       failureRetryBaseDelayMs: 100,
@@ -147,6 +155,7 @@ describe('PollingRuntime state machine', () => {
     tracker.states.A = 'in_progress';
 
     const runtime = new PollingRuntime(tracker, workflow, new FakeLogger(), {
+      ...baseRuntimeOptions,
       now: () => now,
       continuationRetryDelayMs: 100,
       failureRetryBaseDelayMs: 1000,
@@ -173,7 +182,7 @@ describe('PollingRuntime state machine', () => {
     tracker.states.A = 'in_progress';
     const logger = new FakeLogger();
 
-    const runtime = new PollingRuntime(tracker, workflow, logger);
+    const runtime = new PollingRuntime(tracker, workflow, logger, baseRuntimeOptions);
 
     await runtime.tick();
     tracker.failGetStatesByIds = true;
@@ -196,6 +205,7 @@ describe('PollingRuntime state machine', () => {
     tracker.states.A = 'in_progress';
 
     const runtime = new PollingRuntime(tracker, workflow, new FakeLogger(), {
+      ...baseRuntimeOptions,
       now: () => now,
       stallTimeoutMs: 0,
     });
@@ -214,7 +224,7 @@ describe('PollingRuntime state machine', () => {
     tracker.states.A = 'in_progress';
     const logger = new FakeLogger();
 
-    const runtime = new PollingRuntime(tracker, workflow, logger);
+    const runtime = new PollingRuntime(tracker, workflow, logger, baseRuntimeOptions);
 
     await runtime.tick();
     tracker.states.A = 'todo';
@@ -226,5 +236,53 @@ describe('PollingRuntime state machine', () => {
     assert.ok(
       logger.infoLogs.some((log) => log.message === 'runtime.transition.reconcile_stopped_non_active'),
     );
+  });
+
+  it('skips dispatch on preflight failure without skipping reconciliation', async () => {
+    const tracker = new FakeTracker();
+    tracker.items = [item('A', 101), item('B', 102)];
+    tracker.states.A = 'in_progress';
+
+    const logger = new FakeLogger();
+    const runtime = new PollingRuntime(tracker, workflow, logger, baseRuntimeOptions);
+
+    await runtime.tick();
+
+    runtime.applyWorkflow({
+      ...workflow,
+      tracker: {
+        ...workflow.tracker,
+        github: { ...workflow.tracker.github, tokenEnv: 'MISSING_TOKEN' },
+      },
+    });
+
+    await runtime.tick();
+
+    assert.equal(tracker.markInProgressCalls.length, 1);
+    assert.ok(tracker.getStatesByIdsCalls >= 1);
+    assert.ok(logger.warnLogs.some((log) => log.message === 'runtime.preflight.failed'));
+  });
+
+  it('applies workflow update dynamically and uses updated maxConcurrency', async () => {
+    const tracker = new FakeTracker();
+    tracker.items = [item('A', 101), item('B', 102)];
+
+    const logger = new FakeLogger();
+    const runtime = new PollingRuntime(tracker, workflow, logger, baseRuntimeOptions);
+
+    await runtime.tick();
+    assert.equal(tracker.markInProgressCalls.length, 1);
+
+    runtime.applyWorkflow({
+      ...workflow,
+      polling: {
+        ...workflow.polling,
+        maxConcurrency: 2,
+      },
+    });
+
+    await runtime.tick();
+    assert.equal(tracker.markInProgressCalls.length, 2);
+    assert.ok(logger.infoLogs.some((log) => log.message === 'runtime.config.applied'));
   });
 });

--- a/src/orchestrator/runtime.ts
+++ b/src/orchestrator/runtime.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import type { Logger } from '../logging/logger.js';
 import type { NormalizedWorkItem, WorkItemState } from '../model/work-item.js';
 import type { TrackerAdapter } from '../tracker/adapter.js';
@@ -38,6 +39,8 @@ export interface PollingRuntimeOptions {
   failureRetryBaseDelayMs?: number;
   failureRetryMultiplier?: number;
   failureRetryMaxDelayMs?: number;
+  env?: Record<string, string | undefined>;
+  commandExists?: (command: string) => boolean;
 }
 
 const DEFAULT_STALL_TIMEOUT_MS = 5 * 60 * 1000;
@@ -57,13 +60,17 @@ export class PollingRuntime implements OrchestratorRuntime {
   private readonly failureRetryBaseDelayMs: number;
   private readonly failureRetryMultiplier: number;
   private readonly failureRetryMaxDelayMs: number;
+  private readonly env: Record<string, string | undefined>;
+  private readonly commandExists: (command: string) => boolean;
+  private workflow: WorkflowContract;
 
   constructor(
     private readonly tracker: TrackerAdapter,
-    private readonly workflow: WorkflowContract,
+    workflow: WorkflowContract,
     private readonly logger: Logger,
     options: PollingRuntimeOptions = {},
   ) {
+    this.workflow = workflow;
     this.now = options.now ?? (() => Date.now());
     this.stallTimeoutMs = options.stallTimeoutMs ?? DEFAULT_STALL_TIMEOUT_MS;
     this.continuationRetryDelayMs =
@@ -72,11 +79,19 @@ export class PollingRuntime implements OrchestratorRuntime {
       options.failureRetryBaseDelayMs ?? DEFAULT_FAILURE_RETRY_BASE_DELAY_MS;
     this.failureRetryMultiplier = options.failureRetryMultiplier ?? DEFAULT_FAILURE_RETRY_MULTIPLIER;
     this.failureRetryMaxDelayMs = options.failureRetryMaxDelayMs ?? DEFAULT_FAILURE_RETRY_MAX_DELAY_MS;
+    this.env = options.env ?? process.env;
+    this.commandExists = options.commandExists ?? defaultCommandExists;
   }
 
   async tick(): Promise<void> {
     await this.reconcile();
     await this.fireDueRetries();
+
+    const preflight = this.runDispatchPreflight();
+    if (!preflight.ok) {
+      this.logger.warn('runtime.preflight.failed', preflight.context);
+      return;
+    }
 
     const maxConcurrency = this.resolveMaxConcurrency();
     if (maxConcurrency <= 0) {
@@ -157,6 +172,49 @@ export class PollingRuntime implements OrchestratorRuntime {
       retryAttempts,
       completed: [...this.completed],
     };
+  }
+
+  applyWorkflow(nextWorkflow: WorkflowContract): void {
+    this.workflow = nextWorkflow;
+    this.logger.info('runtime.config.applied', {
+      maxConcurrency: nextWorkflow.polling.maxConcurrency ?? 1,
+      pollIntervalMs: nextWorkflow.polling.intervalMs,
+    });
+  }
+
+  private runDispatchPreflight(): { ok: true } | { ok: false; context: Record<string, unknown> } {
+    const github = this.workflow.tracker?.github;
+    if (!github?.owner || !Number.isInteger(github.projectNumber) || github.projectNumber <= 0) {
+      return {
+        ok: false,
+        context: {
+          reason: 'tracker_config_invalid',
+          owner: github?.owner,
+          projectNumber: github?.projectNumber,
+        },
+      };
+    }
+
+    const tokenEnv = github.tokenEnv;
+    if (typeof tokenEnv !== 'string' || tokenEnv.trim() === '') {
+      return { ok: false, context: { reason: 'tracker_auth_env_missing' } };
+    }
+
+    const token = this.env[tokenEnv];
+    if (!token || token.trim() === '') {
+      return { ok: false, context: { reason: 'tracker_auth_token_unset', tokenEnv } };
+    }
+
+    const command = this.workflow.agent?.command;
+    if (typeof command !== 'string' || command.trim() === '') {
+      return { ok: false, context: { reason: 'agent_command_missing' } };
+    }
+
+    if (!this.commandExists(command)) {
+      return { ok: false, context: { reason: 'agent_command_not_found', command } };
+    }
+
+    return { ok: true };
   }
 
   private async reconcile(): Promise<void> {
@@ -382,6 +440,20 @@ export class PollingRuntime implements OrchestratorRuntime {
     }
     return Math.max(0, Math.floor(configured));
   }
+}
+
+function defaultCommandExists(command: string): boolean {
+  const binary = command.trim().split(/\s+/)[0];
+  if (!binary) return false;
+
+  const result = spawnSync('sh', ['-lc', `command -v ${shellQuote(binary)} >/dev/null 2>&1`], {
+    stdio: 'ignore',
+  });
+  return result.status === 0;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 function sortCandidates(items: NormalizedWorkItem[]): NormalizedWorkItem[] {


### PR DESCRIPTION
## Linked Issue
- Closes #52

## Changes
- Added dispatch preflight in `PollingRuntime`; dispatch is skipped while service loop continues when any of the following is invalid:
  - tracker owner/projectNumber
  - missing `tokenEnv` or token injection
  - missing `agent.command` or command not found on PATH
- Emit warning log `runtime.preflight.failed` on preflight failure
- Added `applyWorkflow()` to dynamically apply hot-reloaded configuration into runtime
  - Emit `runtime.config.applied` when applied
- Kept existing tick order (reconcile -> retry fire -> dispatch); reconcile still runs even when preflight fails

## Test Result
- `npm run lint` ✅
- `npm run build && npm test` ✅ (66 tests passed)
- Added tests for:
  - dispatch stop + reconcile continue on preflight failure
  - immediate `maxConcurrency` reflection after `applyWorkflow()`

## Known Risks
- Command existence check depends on `sh -lc "command -v ..."`, which may differ in non-POSIX environments
- Preflight is a runtime guard; notification/retry policy for workflow-parse failures still depends on loader/reloader design
