### PR TITLE
feat: wire real GitHub Projects adapter in bootstrap

### DIFF
--- a/src/bootstrap.test.ts
+++ b/src/bootstrap.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { bootstrapFromWorkflow } from './bootstrap.js';
+import { bootstrapFromWorkflow, BootstrapConfigurationError } from './bootstrap.js';
 import type { Logger } from './logging/logger.js';
 import type { LoadedWorkflowContract, WorkflowLoader } from './workflow/contract.js';
 
@@ -13,7 +13,7 @@ class StubWorkflowLoader implements WorkflowLoader {
         github: {
           owner: 'kouka-t0yohei',
           projectNumber: 1,
-          tokenEnv: 'GITHUB_TOKEN',
+          tokenEnv: 'BOOTSTRAP_TEST_TOKEN',
         },
       },
       runtime: {
@@ -50,6 +50,7 @@ class CapturingLogger implements Logger {
 
 test('bootstrapFromWorkflow wires runtime and emits bootstrap log', async () => {
   const logger = new CapturingLogger();
+  process.env.BOOTSTRAP_TEST_TOKEN = 'test-token';
 
   const result = await bootstrapFromWorkflow('./WORKFLOW.md', {
     workflowLoader: new StubWorkflowLoader(),
@@ -62,4 +63,20 @@ test('bootstrapFromWorkflow wires runtime and emits bootstrap log', async () => 
   const bootstrapLog = logger.messages.find((entry) => entry.message === 'bootstrap.ready');
   assert.ok(bootstrapLog);
   assert.equal(bootstrapLog?.context?.maxConcurrency, 2);
+});
+
+test('bootstrapFromWorkflow fails fast when tracker auth env var is missing', async () => {
+  delete process.env.BOOTSTRAP_TEST_TOKEN;
+
+  await assert.rejects(
+    bootstrapFromWorkflow('./WORKFLOW.md', {
+      workflowLoader: new StubWorkflowLoader(),
+      logger: new CapturingLogger(),
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof BootstrapConfigurationError);
+      assert.match((error as Error).message, /BOOTSTRAP_TEST_TOKEN/);
+      return true;
+    },
+  );
 });

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,6 +1,8 @@
 import { JsonConsoleLogger, type Logger } from './logging/logger.js';
 import { PollingRuntime, type OrchestratorRuntime } from './orchestrator/runtime.js';
-import { GitHubProjectsAdapterPlaceholder, type TrackerAdapter } from './tracker/adapter.js';
+import { GitHubProjectsAdapter, type TrackerAdapter } from './tracker/adapter.js';
+import { GraphQLClient } from './tracker/graphql-client.js';
+import { GitHubProjectsGraphQLClient } from './tracker/github-projects-client.js';
 import {
   FileWorkflowLoader,
   type LoadedWorkflowContract,
@@ -19,15 +21,22 @@ export interface BootstrapResult {
   logger: Logger;
 }
 
+export class BootstrapConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BootstrapConfigurationError';
+  }
+}
+
 export async function bootstrapFromWorkflow(
   workflowPath: string,
   deps: BootstrapDependencies = {},
 ): Promise<BootstrapResult> {
   const workflowLoader = deps.workflowLoader ?? new FileWorkflowLoader();
-  const tracker = deps.trackerAdapter ?? new GitHubProjectsAdapterPlaceholder();
   const logger = deps.logger ?? new JsonConsoleLogger();
 
   const workflow = await workflowLoader.load(workflowPath);
+  const tracker = deps.trackerAdapter ?? createTrackerFromWorkflow(workflow);
   const runtime = new PollingRuntime(tracker, workflow, logger);
 
   logger.info('bootstrap.ready', {
@@ -42,4 +51,24 @@ export async function bootstrapFromWorkflow(
     runtime,
     logger,
   };
+}
+
+function createTrackerFromWorkflow(workflow: LoadedWorkflowContract): TrackerAdapter {
+  const { owner, projectNumber, tokenEnv } = workflow.tracker.github;
+  const token = process.env[tokenEnv]?.trim();
+
+  if (!token) {
+    throw new BootstrapConfigurationError(
+      `Missing tracker auth token environment variable: ${tokenEnv}`,
+    );
+  }
+
+  const graphQLClient = new GraphQLClient({ token });
+  const projectsClient = new GitHubProjectsGraphQLClient(graphQLClient);
+
+  return new GitHubProjectsAdapter({
+    owner,
+    projectNumber,
+    client: projectsClient,
+  });
 }


### PR DESCRIPTION
## Summary
- replace bootstrap placeholder tracker with the real GitHub Projects adapter wiring
- build the tracker client directly from WORKFLOW.md tracker config (owner/project number/token env)
- fail fast with a clear bootstrap configuration error when tracker auth env is missing

## Testing
- npm test

Fixes #64