### PR TITLE
feat: expand active/terminal state model for GitHub Projects mapping

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -90,6 +90,7 @@ function createTrackerFromWorkflow(workflow: LoadedWorkflowContract): TrackerAda
     projectNumber,
     client: projectsClient,
     writer,
+    activeStates: resolveActiveStates(workflow),
   });
 }
 
@@ -111,6 +112,20 @@ function resolveStatusOptions(workflow: LoadedWorkflowContract): Partial<StatusO
     inProgress,
     done,
   };
+}
+
+function resolveActiveStates(workflow: LoadedWorkflowContract): string[] | undefined {
+  const raw = (workflow.extensions?.github_projects as Record<string, unknown> | undefined)?.active_states;
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+
+  const values = raw
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value.length > 0);
+
+  return values.length > 0 ? values : undefined;
 }
 
 const projectIdCache = new Map<string, string>();

--- a/src/model/work-item.ts
+++ b/src/model/work-item.ts
@@ -1,4 +1,4 @@
-export type WorkItemState = "todo" | "in_progress" | "blocked" | "done";
+export type WorkItemState = "todo" | "in_progress" | "blocked" | "done" | (string & {});
 
 export interface NormalizedWorkItem {
   id: string;
@@ -30,13 +30,16 @@ const STATE_ALIAS: Record<string, WorkItemState> = {
   done: "done",
   completed: "done",
   closed: "done",
+  cancelled: "done",
+  canceled: "done",
+  duplicate: "done",
 };
 
 export function normalizeState(value: string): WorkItemState {
   const normalized = value.trim().toLowerCase();
   const mapped = STATE_ALIAS[normalized];
   if (!mapped) {
-    return "todo";
+    return normalized as WorkItemState;
   }
   return mapped;
 }

--- a/src/orchestrator/runtime.test.ts
+++ b/src/orchestrator/runtime.test.ts
@@ -294,7 +294,7 @@ describe('PollingRuntime state machine', () => {
     const runtime = new PollingRuntime(tracker, workflow, logger, baseRuntimeOptions);
 
     await runtime.tick();
-    tracker.states.A = 'todo';
+    tracker.states.A = 'review';
     tracker.items = [];
     await runtime.tick();
 
@@ -302,6 +302,71 @@ describe('PollingRuntime state machine', () => {
     assert.equal(runtime.snapshot().retryAttempts.A, undefined);
     assert.ok(
       logger.infoLogs.some((log) => log.message === 'runtime.transition.reconcile_stopped_non_active'),
+    );
+  });
+
+  it('treats configured terminal state as completion during reconcile', async () => {
+    const tracker = new FakeTracker();
+    tracker.items = [item('A', 101)];
+    tracker.states.A = 'in_progress';
+
+    const runtime = new PollingRuntime(
+      tracker,
+      {
+        ...workflow,
+        extensions: {
+          github_projects: {
+            terminal_states: ['Done', 'Closed', 'Cancelled', 'Canceled', 'Duplicate'],
+          },
+        },
+      },
+      new FakeLogger(),
+      baseRuntimeOptions,
+    );
+
+    await runtime.tick();
+    tracker.states.A = 'duplicate';
+    tracker.items = [];
+    await runtime.tick();
+
+    assert.equal(runtime.snapshot().running.length, 0);
+    assert.deepEqual(runtime.snapshot().completed, ['A']);
+  });
+
+  it('stops unknown state without cleanup when not active and not terminal', async () => {
+    const tracker = new FakeTracker();
+    tracker.items = [item('A', 101)];
+    tracker.states.A = 'in_progress';
+    const logger = new FakeLogger();
+
+    const runtime = new PollingRuntime(
+      tracker,
+      {
+        ...workflow,
+        extensions: {
+          github_projects: {
+            active_states: ['todo', 'in_progress'],
+            terminal_states: ['done', 'closed'],
+          },
+        },
+      },
+      logger,
+      baseRuntimeOptions,
+    );
+
+    await runtime.tick();
+    tracker.states.A = 'triaged';
+    tracker.items = [];
+    await runtime.tick();
+
+    assert.equal(runtime.snapshot().running.length, 0);
+    assert.deepEqual(runtime.snapshot().completed, []);
+    assert.ok(
+      logger.infoLogs.some(
+        (log) =>
+          log.message === 'runtime.transition.reconcile_stopped_non_active' &&
+          log.data?.state === 'triaged',
+      ),
     );
   });
 

--- a/src/orchestrator/runtime.ts
+++ b/src/orchestrator/runtime.ts
@@ -262,7 +262,7 @@ export class PollingRuntime implements OrchestratorRuntime {
 
     if (result === 'completed') {
       const states = await this.tracker.getStatesByIds([itemId]);
-      if (states[itemId] === 'done') {
+      if (this.isTerminalState(states[itemId])) {
         this.completed.add(itemId);
         this.clearRetry(itemId);
         this.logger.info('runtime.transition.completed', {
@@ -425,7 +425,7 @@ export class PollingRuntime implements OrchestratorRuntime {
         continue;
       }
 
-      if (state === 'done') {
+      if (this.isTerminalState(state)) {
         this.running.delete(itemId);
         this.claimed.delete(itemId);
         this.completed.add(itemId);
@@ -434,11 +434,12 @@ export class PollingRuntime implements OrchestratorRuntime {
           issue_id: entry.item.id,
           issue_identifier: entry.item.identifier,
           session_id: entry.sessionId,
+          state,
         });
         continue;
       }
 
-      if (state !== 'in_progress') {
+      if (!this.isActiveState(state)) {
         this.running.delete(itemId);
         this.claimed.delete(itemId);
         this.clearRetry(itemId);
@@ -654,7 +655,7 @@ export class PollingRuntime implements OrchestratorRuntime {
 
     const blocked = new Set<string>();
     for (const item of withBlockers) {
-      const hasNonTerminal = (item.blocked_by ?? []).some((id) => !isTerminalState(states[id]));
+      const hasNonTerminal = (item.blocked_by ?? []).some((id) => !this.isTerminalState(states[id]));
       if (hasNonTerminal) {
         blocked.add(item.id);
       }
@@ -669,13 +670,51 @@ export class PollingRuntime implements OrchestratorRuntime {
     }
 
     const states = await this.tracker.getStatesByIds(item.blocked_by ?? []);
-    return (item.blocked_by ?? []).some((id) => !isTerminalState(states[id]));
+    return (item.blocked_by ?? []).some((id) => !this.isTerminalState(states[id]));
   }
 
   private shouldMarkDoneOnCompletion(): boolean {
     const value = (this.workflow.extensions?.github_projects as Record<string, unknown> | undefined)
       ?.mark_done_on_completion;
     return value === true;
+  }
+
+  private isActiveState(state: WorkItemState | undefined): boolean {
+    if (!state) return false;
+    return this.resolveActiveStates().has(normalizeStateKey(state));
+  }
+
+  private isTerminalState(state: WorkItemState | undefined): boolean {
+    if (!state) return false;
+    return this.resolveTerminalStates().has(normalizeStateKey(state));
+  }
+
+  private resolveActiveStates(): Set<string> {
+    const defaults = ['todo', 'in_progress', 'blocked'];
+    return this.resolveConfiguredStates('active_states', defaults);
+  }
+
+  private resolveTerminalStates(): Set<string> {
+    const defaults = ['done'];
+    return this.resolveConfiguredStates('terminal_states', defaults);
+  }
+
+  private resolveConfiguredStates(key: 'active_states' | 'terminal_states', defaults: string[]): Set<string> {
+    const raw = (this.workflow.extensions?.github_projects as Record<string, unknown> | undefined)?.[key];
+    if (!Array.isArray(raw)) {
+      return new Set(defaults);
+    }
+
+    const normalized = raw
+      .filter((value): value is string => typeof value === 'string')
+      .map((value) => normalizeStateKey(value))
+      .filter((value) => value.length > 0);
+
+    if (normalized.length === 0) {
+      return new Set(defaults);
+    }
+
+    return new Set(normalized);
   }
 }
 
@@ -708,8 +747,8 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-function isTerminalState(state: WorkItemState | undefined): boolean {
-  return state === 'done' || state === 'blocked';
+function normalizeStateKey(state: string): string {
+  return state.trim().toLowerCase();
 }
 
 function sortCandidates(items: NormalizedWorkItem[]): NormalizedWorkItem[] {

--- a/src/tracker/adapter.test.ts
+++ b/src/tracker/adapter.test.ts
@@ -126,6 +126,7 @@ describe("GitHubProjectsAdapter", () => {
     const mapped = {
       A: item("A", 1, "In Progress", []),
       B: item("B", 2, "Blocked", []),
+      C: item("C", 3, "Cancelled", []),
     };
     const adapter = new GitHubProjectsAdapter({
       owner: "o",
@@ -133,8 +134,30 @@ describe("GitHubProjectsAdapter", () => {
       client: new FakeClient([], mapped),
     });
 
-    const states = await adapter.getStatesByIds(["A", "B"]);
-    assert.deepEqual(states, { A: "in_progress", B: "blocked" });
+    const states = await adapter.getStatesByIds(["A", "B", "C"]);
+    assert.deepEqual(states, { A: "in_progress", B: "blocked", C: "done" });
+  });
+
+  it('uses configured active states when listing candidates', async () => {
+    const client = new FakeClient([
+      {
+        items: [item('A', 101, 'Todo', []), item('B', 102, 'Review', [])],
+        hasNextPage: false,
+        endCursor: null,
+      },
+    ]);
+
+    const adapter = new GitHubProjectsAdapter({
+      owner: 'o',
+      projectNumber: 1,
+      client,
+      activeStates: ['review'],
+    });
+
+    const candidates = await adapter.listCandidateItems();
+    assert.equal(candidates.length, 1);
+    assert.equal(candidates[0].id, 'B');
+    assert.equal(candidates[0].state, 'review');
   });
 
   it("throws malformed payload error when issue content is missing", async () => {

--- a/src/tracker/adapter.ts
+++ b/src/tracker/adapter.ts
@@ -26,6 +26,7 @@ export interface GitHubProjectsAdapterOptions {
   client: GitHubProjectsClient;
   writer?: TrackerWriter;
   pageSize?: number;
+  activeStates?: WorkItemState[];
 }
 
 export class GitHubProjectsAdapter implements TrackerAdapter {
@@ -34,6 +35,7 @@ export class GitHubProjectsAdapter implements TrackerAdapter {
   private readonly client: GitHubProjectsClient;
   private readonly writer?: TrackerWriter;
   private readonly defaultPageSize: number;
+  private readonly defaultActiveStates: WorkItemState[];
 
   constructor(options: GitHubProjectsAdapterOptions) {
     this.owner = options.owner;
@@ -41,6 +43,10 @@ export class GitHubProjectsAdapter implements TrackerAdapter {
     this.client = options.client;
     this.writer = options.writer;
     this.defaultPageSize = options.pageSize ?? 50;
+    this.defaultActiveStates =
+      options.activeStates && options.activeStates.length > 0
+        ? [...options.activeStates]
+        : ['todo', 'in_progress', 'blocked'];
   }
 
   async listEligibleItems(): Promise<NormalizedWorkItem[]> {
@@ -51,7 +57,7 @@ export class GitHubProjectsAdapter implements TrackerAdapter {
     pageSize?: number;
     activeStates?: WorkItemState[];
   }): Promise<NormalizedWorkItem[]> {
-    const activeStates = options?.activeStates ?? ["todo", "in_progress", "blocked"];
+    const activeStates = options?.activeStates ?? this.defaultActiveStates;
     return this.listItemsByStates(activeStates, { pageSize: options?.pageSize });
   }
 
@@ -60,7 +66,7 @@ export class GitHubProjectsAdapter implements TrackerAdapter {
     options?: { pageSize?: number },
   ): Promise<NormalizedWorkItem[]> {
     const pageSize = options?.pageSize ?? this.defaultPageSize;
-    const target = new Set(states);
+    const target = new Set(states.map((state) => normalizeState(String(state))));
     const acc: NormalizedWorkItem[] = [];
 
     let after: string | undefined;


### PR DESCRIPTION
## Summary

Implements issue #68 by making state handling configurable and case-insensitive across tracker mapping and runtime reconciliation paths.

## Changes

- Add `extensions.github_projects.active_states` support during candidate fetch in the GitHub Projects adapter
- Add `extensions.github_projects.terminal_states` support in runtime reconciliation and completion checks
- Normalize state comparisons case-insensitively
- Expand default alias mapping so `closed`, `cancelled`, `canceled`, and `duplicate` map to `done`
- Add coverage for configurable active/terminal behavior and mapping policy

## Testing

- `npm test`

Closes #68