### PR TITLE
feat: strengthen preflight + per-tick revalidation surface

### DIFF
--- a/src/bootstrap.test.ts
+++ b/src/bootstrap.test.ts
@@ -80,3 +80,75 @@ test('bootstrapFromWorkflow fails fast when tracker auth env var is missing', as
     },
   );
 });
+
+class InvalidTrackerOwnerLoader implements WorkflowLoader {
+  async load(_path: string): Promise<LoadedWorkflowContract> {
+    return {
+      tracker: {
+        kind: 'github_projects',
+        github: {
+          owner: '',
+          projectNumber: 1,
+          tokenEnv: 'BOOTSTRAP_TEST_TOKEN',
+        },
+      },
+      runtime: { pollIntervalMs: 60_000, maxConcurrency: 1 },
+      polling: { intervalMs: 60_000, maxConcurrency: 1 },
+      workspace: { root: './tmp/workspaces', baseDir: './tmp/workspaces' },
+      agent: { command: 'codex' },
+      prompt_template: 'Run the workflow',
+    };
+  }
+}
+
+class MissingAgentCommandLoader implements WorkflowLoader {
+  async load(_path: string): Promise<LoadedWorkflowContract> {
+    return {
+      tracker: {
+        kind: 'github_projects',
+        github: {
+          owner: 'kouka-t0yohei',
+          projectNumber: 1,
+          tokenEnv: 'BOOTSTRAP_TEST_TOKEN',
+        },
+      },
+      runtime: { pollIntervalMs: 60_000, maxConcurrency: 1 },
+      polling: { intervalMs: 60_000, maxConcurrency: 1 },
+      workspace: { root: './tmp/workspaces', baseDir: './tmp/workspaces' },
+      agent: { command: '' },
+      prompt_template: 'Run the workflow',
+    };
+  }
+}
+
+test('bootstrapFromWorkflow fails fast when tracker.github.owner is missing', async () => {
+  process.env.BOOTSTRAP_TEST_TOKEN = 'test-token';
+
+  await assert.rejects(
+    bootstrapFromWorkflow('./WORKFLOW.md', {
+      workflowLoader: new InvalidTrackerOwnerLoader(),
+      logger: new CapturingLogger(),
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof BootstrapConfigurationError);
+      assert.match((error as Error).message, /tracker\.github\.owner/);
+      return true;
+    },
+  );
+});
+
+test('bootstrapFromWorkflow fails fast when agent.command is missing', async () => {
+  process.env.BOOTSTRAP_TEST_TOKEN = 'test-token';
+
+  await assert.rejects(
+    bootstrapFromWorkflow('./WORKFLOW.md', {
+      workflowLoader: new MissingAgentCommandLoader(),
+      logger: new CapturingLogger(),
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof BootstrapConfigurationError);
+      assert.match((error as Error).message, /agent\.command/);
+      return true;
+    },
+  );
+});

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,5 +1,10 @@
 import { JsonConsoleLogger, type Logger } from './logging/logger.js';
-import { PollingRuntime, type OrchestratorRuntime } from './orchestrator/runtime.js';
+import {
+  PollingRuntime,
+  PreflightValidationError,
+  validateRequiredWorkflowFields,
+  type OrchestratorRuntime,
+} from './orchestrator/runtime.js';
 import { GitHubProjectsAdapter, type TrackerAdapter } from './tracker/adapter.js';
 import { GraphQLClient } from './tracker/graphql-client.js';
 import { GitHubProjectsGraphQLClient } from './tracker/github-projects-client.js';
@@ -37,6 +42,20 @@ export async function bootstrapFromWorkflow(
   const logger = deps.logger ?? new JsonConsoleLogger();
 
   const workflow = await workflowLoader.load(workflowPath);
+
+  // Validate required config fields at startup; surface structured errors before any I/O.
+  // Skip when a custom trackerAdapter is injected (test/override path).
+  if (!deps.trackerAdapter) {
+    try {
+      validateRequiredWorkflowFields(workflow);
+    } catch (err) {
+      if (err instanceof PreflightValidationError) {
+        throw new BootstrapConfigurationError(`${err.failingKey}: ${err.message}`);
+      }
+      throw err;
+    }
+  }
+
   const tracker = deps.trackerAdapter ?? createTrackerFromWorkflow(workflow);
   const runtime = new PollingRuntime(tracker, workflow, logger);
 

--- a/src/orchestrator/runtime.test.ts
+++ b/src/orchestrator/runtime.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test';
 
 import type { Logger } from '../logging/logger.js';
 import type { NormalizedWorkItem, WorkItemState } from '../model/work-item.js';
-import { PollingRuntime } from './runtime.js';
+import { PollingRuntime, PreflightValidationError, validateRequiredWorkflowFields } from './runtime.js';
 
 class FakeLogger implements Logger {
   public readonly infoLogs: Array<{ message: string; data?: Record<string, unknown> }> = [];
@@ -654,6 +654,79 @@ describe('PollingRuntime state machine', () => {
     assert.deepEqual(tracker.markInProgressCalls, ['A']);
   });
 
+  it('preflight failure includes failing_key in warn log context', async () => {
+    const tracker = new FakeTracker();
+    tracker.items = [item('A', 101)];
+
+    const logger = new FakeLogger();
+    const runtime = new PollingRuntime(
+      tracker,
+      {
+        ...workflow,
+        tracker: {
+          ...workflow.tracker,
+          github: { ...workflow.tracker.github, tokenEnv: 'MISSING_ENV_KEY' },
+        },
+      },
+      logger,
+      { ...baseRuntimeOptions, env: {} },
+    );
+
+    await runtime.tick();
+
+    const preflightWarn = logger.warnLogs.find((log) => log.message === 'runtime.preflight.failed');
+    assert.ok(preflightWarn, 'expected runtime.preflight.failed warn log');
+    assert.equal(preflightWarn?.data?.failing_key, 'env.MISSING_ENV_KEY');
+    assert.equal(preflightWarn?.data?.reason, 'tracker_auth_token_unset');
+    assert.equal(tracker.markInProgressCalls.length, 0);
+  });
+
+  it('preflight failure for missing agent.command includes failing_key', async () => {
+    const tracker = new FakeTracker();
+    tracker.items = [item('A', 101)];
+
+    const logger = new FakeLogger();
+    const runtime = new PollingRuntime(
+      tracker,
+      { ...workflow, agent: { command: '' } },
+      logger,
+      baseRuntimeOptions,
+    );
+
+    await runtime.tick();
+
+    const preflightWarn = logger.warnLogs.find((log) => log.message === 'runtime.preflight.failed');
+    assert.ok(preflightWarn, 'expected runtime.preflight.failed warn log');
+    assert.equal(preflightWarn?.data?.failing_key, 'agent.command');
+    assert.equal(preflightWarn?.data?.reason, 'agent_command_missing');
+    assert.equal(tracker.markInProgressCalls.length, 0);
+  });
+
+  it('preflight failure for missing tracker owner includes failing_key', async () => {
+    const tracker = new FakeTracker();
+    tracker.items = [item('A', 101)];
+
+    const logger = new FakeLogger();
+    const runtime = new PollingRuntime(
+      tracker,
+      {
+        ...workflow,
+        tracker: {
+          ...workflow.tracker,
+          github: { ...workflow.tracker.github, owner: '' },
+        },
+      },
+      logger,
+      baseRuntimeOptions,
+    );
+
+    await runtime.tick();
+
+    const preflightWarn = logger.warnLogs.find((log) => log.message === 'runtime.preflight.failed');
+    assert.ok(preflightWarn);
+    assert.equal(preflightWarn?.data?.failing_key, 'tracker.github.owner');
+  });
+
   it('aggregates usage/runtime metrics and exposes detailed snapshot state', async () => {
     let now = 5_000;
     const tracker = new FakeTracker();
@@ -711,6 +784,71 @@ describe('PollingRuntime state machine', () => {
       logger.infoLogs.some(
         (log) => log.message === 'runtime.transition.metrics' && log.data?.session_id === 'sess-b',
       ),
+    );
+  });
+});
+
+describe('validateRequiredWorkflowFields', () => {
+  const validWorkflow = {
+    tracker: {
+      kind: 'github_projects' as const,
+      github: { owner: 'owner', projectNumber: 1, tokenEnv: 'MY_TOKEN' },
+    },
+    runtime: { pollIntervalMs: 1000, maxConcurrency: 1 },
+    polling: { intervalMs: 1000, maxConcurrency: 1 },
+    workspace: { root: '/tmp', baseDir: '/tmp' },
+    agent: { command: 'codex' },
+  };
+  const validEnv = { MY_TOKEN: 'tok' };
+
+  it('passes for a fully valid config', () => {
+    assert.doesNotThrow(() => validateRequiredWorkflowFields(validWorkflow, validEnv));
+  });
+
+  it('throws PreflightValidationError with failingKey for missing owner', () => {
+    const w = { ...validWorkflow, tracker: { ...validWorkflow.tracker, github: { ...validWorkflow.tracker.github, owner: '' } } };
+    assert.throws(
+      () => validateRequiredWorkflowFields(w, validEnv),
+      (err: unknown) => {
+        assert.ok(err instanceof PreflightValidationError);
+        assert.equal(err.failingKey, 'tracker.github.owner');
+        return true;
+      },
+    );
+  });
+
+  it('throws PreflightValidationError with failingKey for invalid projectNumber', () => {
+    const w = { ...validWorkflow, tracker: { ...validWorkflow.tracker, github: { ...validWorkflow.tracker.github, projectNumber: 0 } } };
+    assert.throws(
+      () => validateRequiredWorkflowFields(w, validEnv),
+      (err: unknown) => {
+        assert.ok(err instanceof PreflightValidationError);
+        assert.equal(err.failingKey, 'tracker.github.projectNumber');
+        return true;
+      },
+    );
+  });
+
+  it('throws PreflightValidationError with failingKey for unset token env var', () => {
+    assert.throws(
+      () => validateRequiredWorkflowFields(validWorkflow, {}),
+      (err: unknown) => {
+        assert.ok(err instanceof PreflightValidationError);
+        assert.equal(err.failingKey, 'env.MY_TOKEN');
+        return true;
+      },
+    );
+  });
+
+  it('throws PreflightValidationError with failingKey for missing agent command', () => {
+    const w = { ...validWorkflow, agent: { command: '' } };
+    assert.throws(
+      () => validateRequiredWorkflowFields(w, validEnv),
+      (err: unknown) => {
+        assert.ok(err instanceof PreflightValidationError);
+        assert.equal(err.failingKey, 'agent.command');
+        return true;
+      },
     );
   });
 });

--- a/src/orchestrator/runtime.ts
+++ b/src/orchestrator/runtime.ts
@@ -79,6 +79,71 @@ const DEFAULT_FAILURE_RETRY_BASE_DELAY_MS = 10_000;
 const DEFAULT_FAILURE_RETRY_MULTIPLIER = 2;
 const DEFAULT_FAILURE_RETRY_MAX_DELAY_MS = 60_000;
 
+/**
+ * Error thrown when required workflow config fields are missing or invalid.
+ * Includes a `failingKey` field identifying the config path that failed validation.
+ */
+export class PreflightValidationError extends Error {
+  constructor(
+    message: string,
+    readonly failingKey: string,
+  ) {
+    super(message);
+    this.name = 'PreflightValidationError';
+  }
+}
+
+/**
+ * Validates required workflow config fields (tracker, auth, agent command) without
+ * checking command existence on PATH. Safe to call at startup.
+ *
+ * Throws `PreflightValidationError` with `failingKey` identifying the failing path.
+ */
+export function validateRequiredWorkflowFields(
+  workflow: WorkflowContract,
+  env: Record<string, string | undefined> = process.env,
+): void {
+  const github = workflow.tracker?.github;
+
+  if (typeof github?.owner !== 'string' || github.owner.trim() === '') {
+    throw new PreflightValidationError(
+      'tracker.github.owner is required and must be a non-empty string',
+      'tracker.github.owner',
+    );
+  }
+
+  if (!Number.isInteger(github.projectNumber) || github.projectNumber <= 0) {
+    throw new PreflightValidationError(
+      'tracker.github.projectNumber is required and must be a positive integer',
+      'tracker.github.projectNumber',
+    );
+  }
+
+  const tokenEnv = github.tokenEnv;
+  if (typeof tokenEnv !== 'string' || tokenEnv.trim() === '') {
+    throw new PreflightValidationError(
+      'tracker.github.tokenEnv is required and must be a non-empty string',
+      'tracker.github.tokenEnv',
+    );
+  }
+
+  const token = env[tokenEnv];
+  if (!token || token.trim() === '') {
+    throw new PreflightValidationError(
+      `Environment variable ${tokenEnv} (tracker auth token) is not set`,
+      `env.${tokenEnv}`,
+    );
+  }
+
+  const command = workflow.agent?.command;
+  if (typeof command !== 'string' || command.trim() === '') {
+    throw new PreflightValidationError(
+      'agent.command is required and must be a non-empty string',
+      'agent.command',
+    );
+  }
+}
+
 export class PollingRuntime implements OrchestratorRuntime {
   private readonly running = new Map<string, RunningEntry>();
   private readonly claimed = new Set<string>();
@@ -351,12 +416,24 @@ export class PollingRuntime implements OrchestratorRuntime {
 
   private runDispatchPreflight(): { ok: true } | { ok: false; context: Record<string, unknown> } {
     const github = this.workflow.tracker?.github;
-    if (!github?.owner || !Number.isInteger(github.projectNumber) || github.projectNumber <= 0) {
+
+    if (typeof github?.owner !== 'string' || github.owner.trim() === '') {
       return {
         ok: false,
         context: {
           reason: 'tracker_config_invalid',
+          failing_key: 'tracker.github.owner',
           owner: github?.owner,
+        },
+      };
+    }
+
+    if (!Number.isInteger(github.projectNumber) || github.projectNumber <= 0) {
+      return {
+        ok: false,
+        context: {
+          reason: 'tracker_config_invalid',
+          failing_key: 'tracker.github.projectNumber',
           projectNumber: github?.projectNumber,
         },
       };
@@ -364,21 +441,37 @@ export class PollingRuntime implements OrchestratorRuntime {
 
     const tokenEnv = github.tokenEnv;
     if (typeof tokenEnv !== 'string' || tokenEnv.trim() === '') {
-      return { ok: false, context: { reason: 'tracker_auth_env_missing' } };
+      return {
+        ok: false,
+        context: { reason: 'tracker_auth_env_missing', failing_key: 'tracker.github.tokenEnv' },
+      };
     }
 
     const token = this.env[tokenEnv];
     if (!token || token.trim() === '') {
-      return { ok: false, context: { reason: 'tracker_auth_token_unset', tokenEnv } };
+      return {
+        ok: false,
+        context: {
+          reason: 'tracker_auth_token_unset',
+          failing_key: `env.${tokenEnv}`,
+          tokenEnv,
+        },
+      };
     }
 
     const command = this.workflow.agent?.command;
     if (typeof command !== 'string' || command.trim() === '') {
-      return { ok: false, context: { reason: 'agent_command_missing' } };
+      return {
+        ok: false,
+        context: { reason: 'agent_command_missing', failing_key: 'agent.command' },
+      };
     }
 
     if (!this.commandExists(command)) {
-      return { ok: false, context: { reason: 'agent_command_not_found', command } };
+      return {
+        ok: false,
+        context: { reason: 'agent_command_not_found', failing_key: 'agent.command', command },
+      };
     }
 
     return { ok: true };


### PR DESCRIPTION
## Summary

Strengthens startup and per-tick preflight validation to fully match the GitHub-adapted orchestration contract. Invalid required config now fails fast at bootstrap; every dispatch-blocking preflight error includes a structured `failing_key` field for operator visibility.

## Changes

- **`runtime.ts`**: Export `PreflightValidationError` (with `failingKey` field) and `validateRequiredWorkflowFields` — validates `tracker.github.owner`, `projectNumber`, `tokenEnv`, token value, and `agent.command`; does not check command existence on PATH (tick-time only).
- **`runtime.ts`**: Updated `runDispatchPreflight()` to include `failing_key` in every warn-log context, enabling operators to identify the exact failing config path.
- **`bootstrap.ts`**: Calls `validateRequiredWorkflowFields` in `bootstrapFromWorkflow` (skipped when a custom `trackerAdapter` is injected); wraps as `BootstrapConfigurationError` for structured startup failures.
- **`runtime.test.ts`**: New tests covering `failing_key` in preflight warn logs (token, agent.command, owner), plus full unit tests for `validateRequiredWorkflowFields`.
- **`bootstrap.test.ts`**: New tests for startup failure on missing `tracker.github.owner` and `agent.command`.

## Testing

All 90 tests pass (`npm test`). TypeScript type-check clean (`npm run typecheck`).

Fixes t0yohei/symphony-github-projects#70