### PR TITLE
feat: align Codex timeout defaults and runtime accounting

### DIFF
--- a/src/agent/codex-app-server.test.ts
+++ b/src/agent/codex-app-server.test.ts
@@ -313,3 +313,139 @@ test('classifies rate limit errors from stderr', async () => {
   assert.equal(result.status, 'rate_limited');
   assert.match(result.errorMessage ?? '', /rate limit/i);
 });
+
+test('snapshot includes runtimeSeconds greater than zero after run completes', async () => {
+  const fake = new FakeChildProcess();
+  const client = new CodexAppServerClient({
+    cwd: '/tmp/workspace',
+    readTimeoutMs: 10,
+    stallTimeoutMs: 500,
+    spawn: () => {
+      queueMicrotask(() => {
+        fake.emitStdoutJson({ method: 'initialized' });
+        fake.emitStdoutJson({
+          params: { turn: { completed: true, active_issue: false } },
+        });
+      });
+      return fake;
+    },
+  });
+
+  const result = await client.run({ renderedPrompt: 'runtime test' });
+
+  assert.equal(result.status, 'completed');
+  assert.ok(
+    typeof result.state.runtimeSeconds === 'number' && result.state.runtimeSeconds >= 0,
+    `runtimeSeconds should be a non-negative number, got ${result.state.runtimeSeconds}`,
+  );
+});
+
+test('snapshot runtimeSeconds reflects elapsed time on stall', async () => {
+  const fake = new FakeChildProcess();
+  const client = new CodexAppServerClient({
+    cwd: '/tmp/workspace',
+    readTimeoutMs: 5,
+    stallTimeoutMs: 30,
+    turnTimeoutMs: 500,
+    spawn: () => fake,
+  });
+
+  const before = Date.now();
+  const result = await client.run({ renderedPrompt: 'will stall for timing' });
+  const after = Date.now();
+
+  assert.equal(result.status, 'stalled');
+  // runtimeSeconds should be between 0 and the total elapsed wall time.
+  const elapsedSeconds = (after - before) / 1000;
+  assert.ok(
+    result.state.runtimeSeconds >= 0 && result.state.runtimeSeconds <= elapsedSeconds + 0.1,
+    `runtimeSeconds (${result.state.runtimeSeconds}) out of expected range [0, ${elapsedSeconds + 0.1}]`,
+  );
+});
+
+test('snapshot runtimeSeconds reflects elapsed time on turn timeout', async () => {
+  const fake = new FakeChildProcess();
+  const client = new CodexAppServerClient({
+    cwd: '/tmp/workspace',
+    readTimeoutMs: 5,
+    stallTimeoutMs: 60_000,
+    turnTimeoutMs: 40,
+    spawn: () => {
+      // Emit initialized but no turn completion — triggers turn timeout.
+      queueMicrotask(() => {
+        fake.emitStdoutJson({ method: 'initialized' });
+        // Emit periodic events to keep stall timer alive, but never complete.
+        const interval = setInterval(() => {
+          fake.emitStdoutJson({ method: 'ping' });
+        }, 5);
+        setTimeout(() => clearInterval(interval), 200);
+      });
+      return fake;
+    },
+  });
+
+  const before = Date.now();
+  const result = await client.run({ renderedPrompt: 'will timeout' });
+  const after = Date.now();
+
+  assert.equal(result.status, 'timeout');
+  const elapsedSeconds = (after - before) / 1000;
+  assert.ok(
+    result.state.runtimeSeconds >= 0 && result.state.runtimeSeconds <= elapsedSeconds + 0.1,
+    `runtimeSeconds (${result.state.runtimeSeconds}) out of expected range [0, ${elapsedSeconds + 0.1}]`,
+  );
+});
+
+test('snapshot records latestRateLimitAt when rate_limited event is observed', async () => {
+  const fake = new FakeChildProcess();
+  const beforeRun = Date.now();
+
+  const client = new CodexAppServerClient({
+    cwd: '/tmp/workspace',
+    readTimeoutMs: 10,
+    stallTimeoutMs: 1000,
+    turnTimeoutMs: 1000,
+    spawn: () => {
+      queueMicrotask(() => {
+        fake.emitStdoutJson({ method: 'initialized' });
+        fake.emitStdoutJson({ params: { rate_limited: true, error: { message: 'rate limited' } } });
+      });
+      return fake;
+    },
+  });
+
+  const result = await client.run({ renderedPrompt: 'rate limit tracking' });
+
+  assert.equal(result.status, 'rate_limited');
+  assert.ok(
+    typeof result.state.latestRateLimitAt === 'number',
+    'latestRateLimitAt should be set when rate_limited event is received',
+  );
+  assert.ok(
+    (result.state.latestRateLimitAt ?? 0) >= beforeRun,
+    'latestRateLimitAt should be >= the time before the run started',
+  );
+});
+
+test('snapshot latestRateLimitAt is undefined when no rate limit occurred', async () => {
+  const fake = new FakeChildProcess();
+  const client = new CodexAppServerClient({
+    cwd: '/tmp/workspace',
+    readTimeoutMs: 10,
+    stallTimeoutMs: 500,
+    spawn: () => {
+      queueMicrotask(() => {
+        fake.emitStdoutJson({ method: 'initialized' });
+        fake.emitStdoutJson({
+          params: { turn: { completed: true, active_issue: false } },
+        });
+      });
+      return fake;
+    },
+  });
+
+  const result = await client.run({ renderedPrompt: 'no rate limit' });
+
+  assert.equal(result.status, 'completed');
+  assert.equal(result.state.latestRateLimitAt, undefined);
+});

--- a/src/agent/codex-app-server.ts
+++ b/src/agent/codex-app-server.ts
@@ -15,6 +15,10 @@ export interface CodexSessionState {
   turnsStarted: number;
   turnsCompleted: number;
   usage: CodexUsageCounters;
+  /** Elapsed wall-clock time in seconds from when run() was called to the most recent snapshot. */
+  runtimeSeconds: number;
+  /** Unix timestamp (ms) of the most recent rate-limit signal, or undefined if none was observed. */
+  latestRateLimitAt?: number;
 }
 
 export interface CodexTurnResult {
@@ -69,9 +73,31 @@ type SpawnLike = (
   },
 ) => ChildProcessLike;
 
+/**
+ * Default maximum number of agent turns per run().
+ * Aligns with Symphony SPEC multi-turn contract: agents may need up to 3 turns
+ * for complex tasks while keeping per-issue resource usage bounded.
+ */
 const DEFAULT_MAX_TURNS = 3;
+
+/**
+ * Default per-turn wall-clock timeout (ms).
+ * Matches the WORKFLOW.md hooks.timeout_ms recommendation (120 s).
+ * Raise for exceptionally long-running code generation tasks.
+ */
 const DEFAULT_TURN_TIMEOUT_MS = 120_000;
+
+/**
+ * Default read (poll) interval for the completion-wait loop (ms).
+ * Low enough to detect completion promptly; not so low as to busy-spin.
+ */
 const DEFAULT_READ_TIMEOUT_MS = 10_000;
+
+/**
+ * Default stall timeout (ms): time since the last stdout/stderr event before
+ * the turn is considered hung. 30 s gives the agent headroom for slow model
+ * responses while still bounding deadlock scenarios.
+ */
 const DEFAULT_STALL_TIMEOUT_MS = 30_000;
 
 /** Format the thread title as "<identifier>: <title>" when both are provided. */
@@ -92,7 +118,12 @@ export class CodexAppServerClient {
       outputTokens: 0,
       totalTokens: 0,
     },
+    runtimeSeconds: 0,
+    latestRateLimitAt: undefined,
   };
+
+  /** Timestamp (ms) when run() was invoked; set at the start of each run. */
+  private runStartedAt: number | undefined;
 
   private readonly maxTurns: number;
   private readonly turnTimeoutMs: number;
@@ -120,6 +151,8 @@ export class CodexAppServerClient {
   }
 
   async run(params: RunTurnParams): Promise<CodexTurnResult> {
+    this.runStartedAt = Date.now();
+
     const child = this.spawnProc(this.command, this.args, {
       cwd: this.options.cwd,
       env: {
@@ -404,9 +437,24 @@ export class CodexAppServerClient {
     } else {
       this.state.usage.totalTokens = this.state.usage.inputTokens + this.state.usage.outputTokens;
     }
+
+    // Track the most recent rate-limit signal for reporting/backoff consumers.
+    const rateLimited = readBoolean(event, [
+      'params.rate_limited',
+      'rate_limited',
+      'error.rate_limited',
+    ]);
+    if (rateLimited) {
+      this.state.latestRateLimitAt = Date.now();
+    }
   }
 
   private snapshotState(): CodexSessionState {
+    const runtimeSeconds =
+      this.runStartedAt !== undefined
+        ? (Date.now() - this.runStartedAt) / 1000
+        : 0;
+
     return {
       sessionId: this.state.sessionId,
       threadId: this.state.threadId,
@@ -418,6 +466,8 @@ export class CodexAppServerClient {
         outputTokens: this.state.usage.outputTokens,
         totalTokens: this.state.usage.totalTokens,
       },
+      runtimeSeconds,
+      latestRateLimitAt: this.state.latestRateLimitAt,
     };
   }
 }


### PR DESCRIPTION
## Summary

Implements #72 — align Codex timeout defaults and runtime accounting.

## Changes

### `src/agent/codex-app-server.ts`

**Documented defaults (acceptance criterion 1)**

All four `DEFAULT_*` constants now have JSDoc comments linking them to the Symphony SPEC and `WORKFLOW.md` contract:

| Constant | Value | Rationale |
|---|---|---|
| `DEFAULT_MAX_TURNS` | 3 | Bounds per-issue resource usage while allowing complex tasks |
| `DEFAULT_TURN_TIMEOUT_MS` | 120 000 ms | Matches `hooks.timeout_ms` recommendation in WORKFLOW.md |
| `DEFAULT_READ_TIMEOUT_MS` | 10 000 ms | Low enough to detect completion promptly |
| `DEFAULT_STALL_TIMEOUT_MS` | 30 000 ms | Headroom for slow model responses while bounding deadlock |

**Runtime accounting (acceptance criterion 2)**

- `CodexSessionState` gains two new fields:
  - `runtimeSeconds: number` — elapsed wall-clock seconds from `run()` start to snapshot, available for both live and ended sessions
  - `latestRateLimitAt?: number` — Unix timestamp (ms) of the most recent rate-limit signal; `undefined` when none was observed
- `snapshotState()` populates both fields on every code path
- `applyEvent()` records `latestRateLimitAt` when a `rate_limited` event is received

### `src/agent/codex-app-server.test.ts`

**New tests (acceptance criterion 3)**

- `snapshot includes runtimeSeconds greater than zero after run completes`
- `snapshot runtimeSeconds reflects elapsed time on stall`
- `snapshot runtimeSeconds reflects elapsed time on turn timeout`
- `snapshot records latestRateLimitAt when rate_limited event is observed`
- `snapshot latestRateLimitAt is undefined when no rate limit occurred`

## Test result

All tests pass (`npm run test`).

Closes #72