### PR TITLE
Use GitHub Projects fields for blocker extraction

### DIFF
--- a/src/tracker/adapter.test.ts
+++ b/src/tracker/adapter.test.ts
@@ -1,9 +1,9 @@
-import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 
-import { GitHubProjectsAdapter } from "./adapter.js";
-import type { GitHubProjectsClient, ProjectItemNode } from "./github-projects-client.js";
-import { TrackerMalformedPayloadError } from "./github-projects-client.js";
+import { GitHubProjectsAdapter } from './adapter.js';
+import type { GitHubProjectsClient, ProjectItemNode } from './github-projects-client.js';
+import { TrackerMalformedPayloadError } from './github-projects-client.js';
 
 class FakeClient implements GitHubProjectsClient {
   constructor(
@@ -26,26 +26,33 @@ class FakeClient implements GitHubProjectsClient {
   }
 }
 
-function item(id: string, number: number, state: string, labels: string[]): ProjectItemNode {
+function item(
+  id: string,
+  number: number,
+  state: string,
+  labels: string[],
+  overrides?: Partial<ProjectItemNode>,
+): ProjectItemNode {
   return {
     id,
     content: {
-      __typename: "Issue",
+      __typename: 'Issue',
       number,
       title: `Issue ${number}`,
       body: `Body ${number}`,
       url: `https://example.com/${number}`,
-      createdAt: "2026-01-01T00:00:00Z",
-      updatedAt: "2026-01-02T00:00:00Z",
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-02T00:00:00Z',
       labels: { nodes: labels.map((name) => ({ name })) },
     },
     fieldValues: {
-      nodes: [{ __typename: "ProjectV2ItemFieldSingleSelectValue", name: state }],
+      nodes: [{ __typename: 'ProjectV2ItemFieldSingleSelectValue', name: state }],
     },
+    ...overrides,
   };
 }
 
-describe("GitHubProjectsAdapter", () => {
+describe('GitHubProjectsAdapter', () => {
   it('delegates markInProgress/markDone to writer when configured', async () => {
     const calls: string[] = [];
     const adapter = new GitHubProjectsAdapter({
@@ -73,14 +80,14 @@ describe("GitHubProjectsAdapter", () => {
     await assert.rejects(() => adapter.markInProgress('A'), /writer is not configured/i);
     await assert.rejects(() => adapter.markDone('A'), /writer is not configured/i);
   });
-  it("paginates candidate fetch and keeps deterministic normalization", async () => {
+  it('paginates candidate fetch and keeps deterministic normalization', async () => {
     const client = new FakeClient([
-      { items: [item("A", 101, "Todo", ["Bug", "P1"])], hasNextPage: true, endCursor: "1" },
-      { items: [item("B", 102, "Done", ["Feature"])], hasNextPage: false, endCursor: null },
+      { items: [item('A', 101, 'Todo', ['Bug', 'P1'])], hasNextPage: true, endCursor: '1' },
+      { items: [item('B', 102, 'Done', ['Feature'])], hasNextPage: false, endCursor: null },
     ]);
 
     const adapter = new GitHubProjectsAdapter({
-      owner: "t0yohei",
+      owner: 't0yohei',
       projectNumber: 1,
       client,
       pageSize: 1,
@@ -89,53 +96,53 @@ describe("GitHubProjectsAdapter", () => {
     const candidates = await adapter.listCandidateItems();
     assert.equal(candidates.length, 1);
     assert.deepEqual(candidates[0], {
-      id: "A",
-      identifier: "#101",
+      id: 'A',
+      identifier: '#101',
       number: 101,
-      title: "Issue 101",
-      body: "Body 101",
-      description: "Body 101",
-      state: "todo",
+      title: 'Issue 101',
+      body: 'Body 101',
+      description: 'Body 101',
+      state: 'todo',
       priority: null,
-      labels: ["bug", "p1"],
+      labels: ['bug', 'p1'],
       blocked_by: [],
       assignees: [],
-      created_at: "2026-01-01T00:00:00Z",
-      updated_at: "2026-01-02T00:00:00Z",
-      updatedAt: "2026-01-02T00:00:00Z",
-      url: "https://example.com/101",
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-02T00:00:00Z',
+      updatedAt: '2026-01-02T00:00:00Z',
+      url: 'https://example.com/101',
     });
   });
 
-  it("fetches items by explicit states", async () => {
+  it('fetches items by explicit states', async () => {
     const client = new FakeClient([
       {
-        items: [item("A", 101, "Todo", []), item("B", 102, "Done", [])],
+        items: [item('A', 101, 'Todo', []), item('B', 102, 'Done', [])],
         hasNextPage: false,
         endCursor: null,
       },
     ]);
-    const adapter = new GitHubProjectsAdapter({ owner: "o", projectNumber: 1, client });
+    const adapter = new GitHubProjectsAdapter({ owner: 'o', projectNumber: 1, client });
 
-    const done = await adapter.listItemsByStates(["done"]);
+    const done = await adapter.listItemsByStates(['done']);
     assert.equal(done.length, 1);
-    assert.equal(done[0].id, "B");
+    assert.equal(done[0].id, 'B');
   });
 
-  it("fetches state map by ids", async () => {
+  it('fetches state map by ids', async () => {
     const mapped = {
-      A: item("A", 1, "In Progress", []),
-      B: item("B", 2, "Blocked", []),
-      C: item("C", 3, "Cancelled", []),
+      A: item('A', 1, 'In Progress', []),
+      B: item('B', 2, 'Blocked', []),
+      C: item('C', 3, 'Cancelled', []),
     };
     const adapter = new GitHubProjectsAdapter({
-      owner: "o",
+      owner: 'o',
       projectNumber: 1,
       client: new FakeClient([], mapped),
     });
 
-    const states = await adapter.getStatesByIds(["A", "B", "C"]);
-    assert.deepEqual(states, { A: "in_progress", B: "blocked", C: "done" });
+    const states = await adapter.getStatesByIds(['A', 'B', 'C']);
+    assert.deepEqual(states, { A: 'in_progress', B: 'blocked', C: 'done' });
   });
 
   it('uses configured active states when listing candidates', async () => {
@@ -160,18 +167,243 @@ describe("GitHubProjectsAdapter", () => {
     assert.equal(candidates[0].state, 'review');
   });
 
-  it("throws malformed payload error when issue content is missing", async () => {
+  it('throws malformed payload error when issue content is missing', async () => {
     const bad: ProjectItemNode = {
-      id: "X",
+      id: 'X',
       content: null,
       fieldValues: { nodes: [] },
     };
     const adapter = new GitHubProjectsAdapter({
-      owner: "o",
+      owner: 'o',
       projectNumber: 1,
       client: new FakeClient([{ items: [bad], hasNextPage: false, endCursor: null }]),
     });
 
     await assert.rejects(() => adapter.listCandidateItems(), TrackerMalformedPayloadError);
+  });
+
+  it('throws malformed payload error when timestamps are missing', async () => {
+    const bad: ProjectItemNode = {
+      id: 'Y',
+      content: {
+        __typename: 'Issue',
+        number: 999,
+        title: 'Issue 999',
+        body: 'Body 999',
+        url: 'https://example.com/999',
+        createdAt: undefined,
+        updatedAt: undefined,
+      },
+      fieldValues: { nodes: [] },
+    };
+
+    const adapter = new GitHubProjectsAdapter({
+      owner: 'o',
+      projectNumber: 1,
+      client: new FakeClient([{ items: [bad], hasNextPage: false, endCursor: null }]),
+    });
+
+    await assert.rejects(() => adapter.listCandidateItems(), /payload missing timestamps/i);
+  });
+
+  it('builds deterministic blocked_by list from referenced issue numbers in body', async () => {
+    const client = new FakeClient([
+      {
+        items: [
+          {
+            id: 'A',
+            content: {
+              __typename: 'Issue',
+              number: 1,
+              title: 'Issue 1',
+              body: 'Depends on #2, #3 and again #2 and #99',
+              url: 'https://example.com/1',
+              createdAt: '2026-01-01T00:00:00Z',
+              updatedAt: '2026-01-02T00:00:00Z',
+            },
+            fieldValues: {
+              nodes: [{ __typename: 'ProjectV2ItemFieldSingleSelectValue', name: 'Todo' }],
+            },
+          },
+          {
+            id: 'B',
+            content: {
+              __typename: 'Issue',
+              number: 2,
+              title: 'Issue 2',
+              body: 'Body',
+              url: 'https://example.com/2',
+              createdAt: '2026-01-01T00:00:00Z',
+              updatedAt: '2026-01-02T00:00:00Z',
+            },
+            fieldValues: {
+              nodes: [{ __typename: 'ProjectV2ItemFieldSingleSelectValue', name: 'Todo' }],
+            },
+          },
+          {
+            id: 'C',
+            content: {
+              __typename: 'Issue',
+              number: 3,
+              title: 'Issue 3',
+              body: 'Body',
+              url: 'https://example.com/3',
+              createdAt: '2026-01-01T00:00:00Z',
+              updatedAt: '2026-01-02T00:00:00Z',
+            },
+            fieldValues: {
+              nodes: [{ __typename: 'ProjectV2ItemFieldSingleSelectValue', name: 'Todo' }],
+            },
+          },
+        ],
+        hasNextPage: false,
+        endCursor: null,
+      },
+    ]);
+
+    const adapter = new GitHubProjectsAdapter({
+      owner: 'o',
+      projectNumber: 1,
+      client,
+      pageSize: 10,
+    });
+
+    const items = await adapter.listCandidateItems();
+    const blockedTarget = items.find((item) => item.id === 'A');
+
+    assert.ok(blockedTarget);
+    assert.deepEqual(blockedTarget.blocked_by, ['B', 'C']);
+  });
+
+  it('prefers Project field-based blocker references when available', async () => {
+    const client = new FakeClient([
+      {
+        items: [
+          {
+            id: 'A',
+            content: {
+              __typename: 'Issue',
+              number: 10,
+              title: 'Issue 10',
+              body: 'Depends on #3',
+              url: 'https://example.com/10',
+              createdAt: '2026-01-01T00:00:00Z',
+              updatedAt: '2026-01-02T00:00:00Z',
+            },
+            fieldValues: {
+              nodes: [
+                { __typename: 'ProjectV2ItemFieldSingleSelectValue', name: 'Todo', field: { name: 'Status' } },
+                {
+                  __typename: 'ProjectV2ItemFieldTextValue',
+                  text: '#2',
+                  field: { name: 'blocked_by' },
+                },
+              ],
+            },
+          },
+          {
+            id: 'B',
+            content: {
+              __typename: 'Issue',
+              number: 2,
+              title: 'Issue 2',
+              body: 'Body',
+              url: 'https://example.com/2',
+              createdAt: '2026-01-01T00:00:00Z',
+              updatedAt: '2026-01-02T00:00:00Z',
+            },
+            fieldValues: { nodes: [{ __typename: 'ProjectV2ItemFieldSingleSelectValue', name: 'Todo' }] },
+          },
+          {
+            id: 'C',
+            content: {
+              __typename: 'Issue',
+              number: 3,
+              title: 'Issue 3',
+              body: 'Body',
+              url: 'https://example.com/3',
+              createdAt: '2026-01-01T00:00:00Z',
+              updatedAt: '2026-01-02T00:00:00Z',
+            },
+            fieldValues: { nodes: [{ __typename: 'ProjectV2ItemFieldSingleSelectValue', name: 'Todo' }] },
+          },
+        ],
+        hasNextPage: false,
+        endCursor: null,
+      },
+    ]);
+
+    const adapter = new GitHubProjectsAdapter({
+      owner: 'o',
+      projectNumber: 1,
+      client,
+      pageSize: 10,
+    });
+
+    const items = await adapter.listCandidateItems();
+    const blockedTarget = items.find((item) => item.id === 'A');
+
+    assert.ok(blockedTarget);
+    assert.deepEqual(blockedTarget.blocked_by, ['B']);
+  });
+
+  it('supports custom blocker field names', async () => {
+    const client = new FakeClient([
+      {
+        items: [
+          {
+            id: 'A',
+            content: {
+              __typename: 'Issue',
+              number: 11,
+              title: 'Issue 11',
+              body: 'Body',
+              url: 'https://example.com/11',
+              createdAt: '2026-01-01T00:00:00Z',
+              updatedAt: '2026-01-02T00:00:00Z',
+            },
+            fieldValues: {
+              nodes: [
+                { __typename: 'ProjectV2ItemFieldSingleSelectValue', name: 'Todo' },
+                {
+                  __typename: 'ProjectV2ItemFieldTextValue',
+                  text: '#2',
+                  field: { name: 'DependsOn' },
+                },
+              ],
+            },
+          },
+          {
+            id: 'B',
+            content: {
+              __typename: 'Issue',
+              number: 2,
+              title: 'Issue 2',
+              body: 'Body',
+              url: 'https://example.com/2',
+              createdAt: '2026-01-01T00:00:00Z',
+              updatedAt: '2026-01-02T00:00:00Z',
+            },
+            fieldValues: { nodes: [{ __typename: 'ProjectV2ItemFieldSingleSelectValue', name: 'Todo' }] },
+          },
+        ],
+        hasNextPage: false,
+        endCursor: null,
+      },
+    ]);
+
+    const adapter = new GitHubProjectsAdapter({
+      owner: 'o',
+      projectNumber: 1,
+      client,
+      pageSize: 10,
+      blockerFieldNames: ['dependsOn'],
+    });
+
+    const items = await adapter.listCandidateItems();
+    const blockedTarget = items.find((item) => item.id === 'A');
+
+    assert.ok(blockedTarget);
+    assert.deepEqual(blockedTarget.blocked_by, ['B']);
   });
 });

--- a/src/tracker/adapter.ts
+++ b/src/tracker/adapter.ts
@@ -1,10 +1,10 @@
-import type { NormalizedWorkItem, WorkItemState } from "../model/work-item.js";
-import { normalizeState } from "../model/work-item.js";
+import type { NormalizedWorkItem, WorkItemState } from '../model/work-item.js';
+import { normalizeState } from '../model/work-item.js';
 import {
   type GitHubProjectsClient,
   type ProjectItemNode,
   TrackerMalformedPayloadError,
-} from "./github-projects-client.js";
+} from './github-projects-client.js';
 
 export interface TrackerAdapter {
   listEligibleItems(): Promise<NormalizedWorkItem[]>;
@@ -27,7 +27,18 @@ export interface GitHubProjectsAdapterOptions {
   writer?: TrackerWriter;
   pageSize?: number;
   activeStates?: WorkItemState[];
+  blockerFieldNames?: string[];
 }
+
+const DEFAULT_BLOCKER_FIELD_NAMES = [
+  'blocked_by',
+  'blocked by',
+  'depends_on',
+  'depends on',
+  'dependencies',
+  'blocked',
+  'depends',
+];
 
 export class GitHubProjectsAdapter implements TrackerAdapter {
   private readonly owner: string;
@@ -36,6 +47,7 @@ export class GitHubProjectsAdapter implements TrackerAdapter {
   private readonly writer?: TrackerWriter;
   private readonly defaultPageSize: number;
   private readonly defaultActiveStates: WorkItemState[];
+  private readonly blockerFieldNames: string[];
 
   constructor(options: GitHubProjectsAdapterOptions) {
     this.owner = options.owner;
@@ -47,6 +59,10 @@ export class GitHubProjectsAdapter implements TrackerAdapter {
       options.activeStates && options.activeStates.length > 0
         ? [...options.activeStates]
         : ['todo', 'in_progress', 'blocked'];
+    this.blockerFieldNames =
+      options.blockerFieldNames && options.blockerFieldNames.length > 0
+        ? options.blockerFieldNames.map((value) => value.toLowerCase())
+        : DEFAULT_BLOCKER_FIELD_NAMES;
   }
 
   async listEligibleItems(): Promise<NormalizedWorkItem[]> {
@@ -67,8 +83,8 @@ export class GitHubProjectsAdapter implements TrackerAdapter {
   ): Promise<NormalizedWorkItem[]> {
     const pageSize = options?.pageSize ?? this.defaultPageSize;
     const target = new Set(states.map((state) => normalizeState(String(state))));
-    const acc: NormalizedWorkItem[] = [];
 
+    const allNodes: ProjectItemNode[] = [];
     let after: string | undefined;
     while (true) {
       const page = await this.client.fetchProjectItemsPage({
@@ -78,18 +94,27 @@ export class GitHubProjectsAdapter implements TrackerAdapter {
         after,
       });
 
-      for (const node of page.items) {
-        const normalized = this.normalizeNode(node);
-        if (target.has(normalized.state)) {
-          acc.push(normalized);
-        }
-      }
+      allNodes.push(...page.items);
 
-      if (!page.hasNextPage || !page.endCursor) break;
+      if (!page.hasNextPage || !page.endCursor) {
+        break;
+      }
       after = page.endCursor;
     }
 
-    return acc;
+    const numberToId = new Map<number, string>();
+    for (const node of allNodes) {
+      if (!node.content || node.content.__typename !== 'Issue') {
+        continue;
+      }
+      numberToId.set(node.content.number, node.id);
+    }
+
+    const normalized = allNodes
+      .map((node) => this.normalizeNode(node, numberToId))
+      .filter((node) => target.has(node.state));
+
+    return normalized;
   }
 
   async getStatesByIds(itemIds: string[]): Promise<Record<string, WorkItemState>> {
@@ -116,22 +141,27 @@ export class GitHubProjectsAdapter implements TrackerAdapter {
     await this.writer.markDone(itemId);
   }
 
-  private normalizeNode(node: ProjectItemNode): NormalizedWorkItem {
-    if (!node.content || node.content.__typename !== "Issue") {
-      throw new TrackerMalformedPayloadError("Project item does not contain Issue content");
+  private normalizeNode(
+    node: ProjectItemNode,
+    numberToId: Map<number, string>,
+  ): NormalizedWorkItem {
+    if (!node.content || node.content.__typename !== 'Issue') {
+      throw new TrackerMalformedPayloadError('Project item does not contain Issue content');
     }
 
     const createdAt = node.content.createdAt;
     const updatedAt = node.content.updatedAt;
     if (!createdAt || !updatedAt) {
-      throw new TrackerMalformedPayloadError("Project item payload missing timestamps");
+      throw new TrackerMalformedPayloadError('Project item payload missing timestamps');
     }
 
     const labels = (node.content.labels?.nodes ?? [])
       .map((label) => label?.name?.trim().toLowerCase())
       .filter((label): label is string => Boolean(label));
 
-    const body = node.content.body ?? "";
+    const body = node.content.body ?? '';
+    const blockerNumbers = this.extractBlockerIssueNumbers(node, body);
+    const blockedBy = this.extractBlockedBy(blockerNumbers, numberToId);
 
     return {
       id: node.id,
@@ -143,24 +173,84 @@ export class GitHubProjectsAdapter implements TrackerAdapter {
       state: this.extractState(node),
       priority: null,
       labels,
-      blocked_by: [],
+      blocked_by: blockedBy,
       assignees: [],
       created_at: createdAt,
       updated_at: updatedAt,
-      updatedAt: updatedAt,
+      updatedAt,
       url: node.content.url,
     };
   }
 
+  private extractBlockerIssueNumbers(node: ProjectItemNode, body: string): number[] {
+    const projectFieldNumbers = this.extractIssueNumbersFromProjectFields(node);
+    if (projectFieldNumbers.length > 0) {
+      return projectFieldNumbers;
+    }
+
+    return parseIssueNumbersFromText(body);
+  }
+
+  private extractIssueNumbersFromProjectFields(node: ProjectItemNode): number[] {
+    const values = node.fieldValues?.nodes ?? [];
+    const blockerNumbers = new Set<number>();
+
+    for (const value of values) {
+      if (!value || value.__typename !== 'ProjectV2ItemFieldTextValue') {
+        continue;
+      }
+
+      const fieldName = value.field?.name?.toLowerCase() ?? '';
+      if (!this.blockerFieldNames.includes(fieldName)) {
+        continue;
+      }
+
+      const fieldText = (value as { text?: string | null }).text ?? '';
+      for (const num of parseIssueNumbersFromText(fieldText)) {
+        blockerNumbers.add(num);
+      }
+    }
+
+    return [...blockerNumbers];
+  }
+
+  private extractBlockedBy(
+    references: number[],
+    numberToId: Map<number, string>,
+  ): string[] {
+    const blockedBy = new Set<string>();
+    for (const number of references) {
+      const id = numberToId.get(number);
+      if (id) {
+        blockedBy.add(id);
+      }
+    }
+
+    return [...blockedBy];
+  }
+
   private extractState(node: ProjectItemNode): WorkItemState {
     const singleSelect =
-      node.fieldValues?.nodes?.find((n) => n?.__typename === "ProjectV2ItemFieldSingleSelectValue") ?? null;
+      node.fieldValues?.nodes?.find((n) => n?.__typename === 'ProjectV2ItemFieldSingleSelectValue') ?? null;
 
-    if (singleSelect && "name" in singleSelect && typeof singleSelect.name === "string") {
+    if (singleSelect && 'name' in singleSelect && typeof singleSelect.name === 'string') {
       return normalizeState(singleSelect.name);
     }
-    return "todo";
+    return 'todo';
   }
+}
+
+function parseIssueNumbersFromText(text: string): number[] {
+  const seen = new Set<number>();
+  const matches = text.match(/#(\d+)/g) ?? [];
+  for (const match of matches) {
+    const value = Number.parseInt(match.slice(1), 10);
+    if (Number.isInteger(value) && value > 0) {
+      seen.add(value);
+    }
+  }
+
+  return [...seen];
 }
 
 export class GitHubProjectsAdapterPlaceholder implements TrackerAdapter {
@@ -181,10 +271,10 @@ export class GitHubProjectsAdapterPlaceholder implements TrackerAdapter {
   }
 
   async markInProgress(_itemId: string): Promise<void> {
-    throw new Error("GitHub Projects write path not implemented yet");
+    throw new Error('GitHub Projects write path not implemented yet');
   }
 
   async markDone(_itemId: string): Promise<void> {
-    throw new Error("GitHub Projects write path not implemented yet");
+    throw new Error('GitHub Projects write path not implemented yet');
   }
 }

--- a/src/tracker/github-projects-client.ts
+++ b/src/tracker/github-projects-client.ts
@@ -1,37 +1,70 @@
-import { GraphQLClient, GraphQLError } from "./graphql-client.js";
+import { GraphQLClient, GraphQLError } from './graphql-client.js';
 
 export class TrackerTransportError extends Error {
   constructor(message: string, public readonly causeError?: unknown) {
     super(message);
-    this.name = "TrackerTransportError";
+    this.name = 'TrackerTransportError';
   }
 }
 
 export class TrackerStatusError extends Error {
   constructor(public readonly status: number, message?: string) {
     super(message ?? `Tracker request failed with status ${status}`);
-    this.name = "TrackerStatusError";
+    this.name = 'TrackerStatusError';
   }
 }
 
 export class TrackerGraphQLError extends Error {
   constructor(message: string, public readonly errors: Array<{ message: string }>) {
     super(message);
-    this.name = "TrackerGraphQLError";
+    this.name = 'TrackerGraphQLError';
   }
 }
 
 export class TrackerMalformedPayloadError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "TrackerMalformedPayloadError";
+    this.name = 'TrackerMalformedPayloadError';
   }
 }
+
+interface ProjectV2FieldNode {
+  name?: string | null;
+}
+
+interface FieldTextValueNode {
+  __typename: 'ProjectV2ItemFieldTextValue';
+  text?: string | null;
+  field?: ProjectV2FieldNode | null;
+}
+
+interface FieldSingleSelectValueNode {
+  __typename: 'ProjectV2ItemFieldSingleSelectValue';
+  name?: string | null;
+  field?: ProjectV2FieldNode | null;
+}
+
+interface FieldNumberValueNode {
+  __typename: 'ProjectV2ItemFieldNumberValue';
+  number?: number | null;
+  field?: ProjectV2FieldNode | null;
+}
+
+interface UnknownFieldValueNode {
+  __typename: string;
+  field?: ProjectV2FieldNode | null;
+}
+
+type ProjectV2ItemFieldValueNode =
+  | FieldTextValueNode
+  | FieldSingleSelectValueNode
+  | FieldNumberValueNode
+  | UnknownFieldValueNode;
 
 export interface ProjectItemNode {
   id: string;
   content: {
-    __typename: "Issue" | "PullRequest";
+    __typename: 'Issue' | 'PullRequest';
     number: number;
     title: string;
     body?: string;
@@ -41,11 +74,7 @@ export interface ProjectItemNode {
     updatedAt?: string;
   } | null;
   fieldValues?: {
-    nodes?: Array<
-      | { __typename: "ProjectV2ItemFieldSingleSelectValue"; name?: string | null }
-      | { __typename: string }
-      | null
-    > | null;
+    nodes?: Array<ProjectV2ItemFieldValueNode | null> | null;
   };
 }
 
@@ -122,6 +151,15 @@ export class GitHubProjectsGraphQLClient implements GitHubProjectsClient {
                     __typename
                     ... on ProjectV2ItemFieldSingleSelectValue {
                       name
+                      field { name }
+                    }
+                    ... on ProjectV2ItemFieldTextValue {
+                      text
+                      field { name }
+                    }
+                    ... on ProjectV2ItemFieldNumberValue {
+                      number
+                      field { name }
                     }
                   }
                 }
@@ -152,6 +190,15 @@ export class GitHubProjectsGraphQLClient implements GitHubProjectsClient {
                     __typename
                     ... on ProjectV2ItemFieldSingleSelectValue {
                       name
+                      field { name }
+                    }
+                    ... on ProjectV2ItemFieldTextValue {
+                      text
+                      field { name }
+                    }
+                    ... on ProjectV2ItemFieldNumberValue {
+                      number
+                      field { name }
                     }
                   }
                 }
@@ -171,7 +218,7 @@ export class GitHubProjectsGraphQLClient implements GitHubProjectsClient {
 
     const connection = data.user?.projectV2?.items ?? data.organization?.projectV2?.items;
     if (!connection) {
-      throw new TrackerMalformedPayloadError("Project items connection missing in GraphQL response");
+      throw new TrackerMalformedPayloadError('Project items connection missing in GraphQL response');
     }
 
     return {
@@ -206,6 +253,15 @@ export class GitHubProjectsGraphQLClient implements GitHubProjectsClient {
                 __typename
                 ... on ProjectV2ItemFieldSingleSelectValue {
                   name
+                  field { name }
+                }
+                ... on ProjectV2ItemFieldTextValue {
+                  text
+                  field { name }
+                }
+                ... on ProjectV2ItemFieldNumberValue {
+                  number
+                  field { name }
                 }
               }
             }
@@ -224,7 +280,7 @@ export class GitHubProjectsGraphQLClient implements GitHubProjectsClient {
     } catch (error) {
       if (error instanceof GraphQLError) {
         const m = error.message.toLowerCase();
-        if (m.includes("failed:") || m.includes("status")) {
+        if (m.includes('failed:') || m.includes('status')) {
           const status = Number(error.message.match(/(\d{3})/)?.[1] ?? 0);
           throw new TrackerStatusError(status || 500, error.message);
         }
@@ -233,7 +289,7 @@ export class GitHubProjectsGraphQLClient implements GitHubProjectsClient {
         }
         throw new TrackerMalformedPayloadError(error.message);
       }
-      throw new TrackerTransportError("Failed to communicate with tracker backend", error);
+      throw new TrackerTransportError('Failed to communicate with tracker backend', error);
     }
   }
 }


### PR DESCRIPTION
## What
- derive issue blockers from GitHub Project field values (prefer text field blockers)
- fallback to body references only when field-based blockers are absent
- add configurable blocker field names
- extend GraphQL item query to fetch text/number field metadata

## Validation
- npm test
- npm run lint
