### PR TITLE
Align GitHub Projects workflow to SPEC expectations

### DIFF
--- a/src/bootstrap.test.ts
+++ b/src/bootstrap.test.ts
@@ -70,6 +70,58 @@ test('bootstrapFromWorkflow wires runtime and emits bootstrap log', async () => 
   assert.equal(bootstrapLog?.context?.maxConcurrency, 2);
 });
 
+
+
+test('bootstrapFromWorkflow uses terminal_states extension for startup cleanup', async () => {
+  class TerminalStateTracker extends StubTracker {
+    public requestedStates: string[] = [];
+    override async listItemsByStates(states: WorkItemState[]): Promise<NormalizedWorkItem[]> {
+      this.requestedStates = states;
+      return [];
+    }
+  }
+
+  const logger = new CapturingLogger();
+  const terminalTracker = new TerminalStateTracker();
+
+  class TerminalLoader implements WorkflowLoader {
+    async load(_path: string): Promise<LoadedWorkflowContract> {
+      return {
+        tracker: {
+          kind: 'github_projects',
+          github: {
+            owner: 'kouka-t0yohei',
+            projectNumber: 1,
+            tokenEnv: 'BOOTSTRAP_TEST_TOKEN',
+          },
+        },
+        runtime: { pollIntervalMs: 60_000, maxConcurrency: 2 },
+        polling: { intervalMs: 60_000, maxConcurrency: 2 },
+        workspace: { root: './tmp/workspaces', baseDir: './tmp/workspaces' },
+        agent: { command: 'codex' },
+        extensions: {
+          github_projects: {
+            terminal_states: ['DONE', 'done'],
+          },
+        },
+        prompt_template: 'Run the workflow',
+      };
+    }
+  }
+
+  process.env.BOOTSTRAP_TEST_TOKEN = 'test-token';
+
+  await bootstrapFromWorkflow('./WORKFLOW.md', {
+    workflowLoader: new TerminalLoader(),
+    trackerAdapter: terminalTracker,
+    logger,
+    skipStartupCleanup: false,
+  });
+
+  assert.deepEqual(terminalTracker.requestedStates, ['done']);
+});
+
+
 test('bootstrapFromWorkflow fails fast when tracker auth env var is missing', async () => {
   delete process.env.BOOTSTRAP_TEST_TOKEN;
 

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -141,26 +141,23 @@ export async function bootstrapFromWorkflow(
   }
 
   if (!deps.skipStartupCleanup) {
-    await performStartupTerminalCleanup(tracker, workspaceRoot, logger);
+    await performStartupTerminalCleanup(tracker, workspaceRoot, logger, resolveTerminalStates(workflow));
   }
 
   const workspaceManager = new WorkspaceManager({
     workspaceRoot,
-    hooks:
-      workflow.hooks ||
-      undefined
-        ? new HookRunner({
-            hooks: {
-              after_create:
-                workflow.hooks?.after_create ?? workflow.hooks?.onStart,
-              before_run: workflow.hooks?.before_run,
-              after_run: workflow.hooks?.after_run ?? workflow.hooks?.onSuccess,
-              before_remove: workflow.hooks?.before_remove,
-            },
-            timeoutMs: workflow.agent.timeouts?.hooksTimeoutMs,
-            logger,
-          })
-        : undefined,
+    hooks: workflow.hooks
+      ? new HookRunner({
+          hooks: {
+            after_create: workflow.hooks?.after_create ?? workflow.hooks?.onStart,
+            before_run: workflow.hooks?.before_run,
+            after_run: workflow.hooks?.after_run ?? workflow.hooks?.onSuccess,
+            before_remove: workflow.hooks?.before_remove,
+          },
+          timeoutMs: workflow.agent.timeouts?.hooksTimeoutMs,
+          logger,
+        })
+      : undefined,
   });
 
   const runtime = new PollingRuntime(tracker, workflow, logger, {
@@ -223,6 +220,21 @@ function createTrackerFromWorkflow(workflow: LoadedWorkflowContract): TrackerAda
     writer,
     activeStates: resolveActiveStates(workflow),
   });
+}
+
+
+function resolveTerminalStates(workflow: LoadedWorkflowContract): string[] {
+  const raw = (workflow.extensions?.github_projects as Record<string, unknown> | undefined)?.terminal_states;
+  if (!Array.isArray(raw)) {
+    return ['done'];
+  }
+
+  const values = raw
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value.length > 0);
+
+  return values.length > 0 ? values : ['done'];
 }
 
 function resolveStatusOptions(workflow: LoadedWorkflowContract): Partial<StatusOptionMapping> | undefined {

--- a/src/orchestrator/runtime.test.ts
+++ b/src/orchestrator/runtime.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import type { Logger } from '../logging/logger.js';
 import type { NormalizedWorkItem, WorkItemState } from '../model/work-item.js';
 import type { CodexTurnResult } from '../agent/codex-app-server.js';
+import type { WorkspaceManager } from '../workspace/manager.js';
 import { PollingRuntime, PreflightValidationError, validateRequiredWorkflowFields } from './runtime.js';
 
 class FakeLogger implements Logger {
@@ -952,6 +953,94 @@ describe('PollingRuntime state machine', () => {
         (log) => log.message === 'runtime.transition.metrics' && log.data?.session_id === 'sess-b',
       ),
     );
+  });
+});
+
+describe('PollingRuntime hot-reload behavior', () => {
+  it('re-applies active states during hot-reload', async () => {
+    class ActiveAwareTracker extends FakeTracker {
+      async listCandidateItems(options?: { pageSize?: number; activeStates?: string[] }): Promise<NormalizedWorkItem[]> {
+        if (!options?.activeStates) {
+          return this.items;
+        }
+        return this.items.filter((candidate) => options.activeStates!.includes(candidate.state));
+      }
+    }
+
+    const tracker = new ActiveAwareTracker();
+    tracker.items = [{ ...item('A', 101), state: 'blocked_custom' as WorkItemState }];
+    tracker.states.A = 'blocked_custom' as WorkItemState;
+
+    const runtime = new PollingRuntime(
+      tracker,
+      {
+        ...workflow,
+        extensions: {
+          github_projects: {
+            active_states: ['todo'],
+          },
+        },
+      },
+      new FakeLogger(),
+      baseRuntimeOptions,
+    );
+
+    await runtime.tick();
+    assert.equal(tracker.markInProgressCalls.length, 0, 'item should not dispatch with initial active states');
+
+    runtime.applyWorkflow({
+      ...workflow,
+      extensions: {
+        github_projects: {
+          active_states: ['blocked_custom'],
+        },
+      },
+    });
+
+    await runtime.tick();
+    assert.equal(tracker.markInProgressCalls.length, 1, 'item should dispatch after active_states changed');
+  });
+
+  it('rebuilds workspace manager when workspace root changes on hot-reload', async () => {
+    const tracker = new FakeTracker();
+    const fakeWorkspaceManager = {
+      prepareWorkspace: async () => ({ path: '/tmp/old-workspace' }),
+      beforeRun: async () => {},
+      afterRun: async () => {},
+      beforeRemove: async () => {},
+      resolveWorkspacePath: () => '/tmp/old-workspace',
+      toWorkspaceKey: () => '_old',
+      cleanupWorkspace: async () => {},
+      toWorkspaceKeyOrThrow: () => '_old',
+      workspaceRoot: '/tmp/first',
+    } as unknown as WorkspaceManager;
+
+
+    const runtime = new PollingRuntime(
+      tracker,
+      {
+        ...workflow,
+        workspace: { root: '/tmp/first', baseDir: '/tmp/first' },
+      },
+      new FakeLogger(),
+      {
+        ...baseRuntimeOptions,
+        workspaceManager: fakeWorkspaceManager,
+      },
+    );
+
+    const runtimeInternals = runtime as unknown as { workspaceManager: { [key: string]: unknown } };
+    assert.equal(runtimeInternals.workspaceManager, fakeWorkspaceManager);
+
+    runtime.applyWorkflow({
+      ...workflow,
+      workspace: { root: '/tmp/second', baseDir: '/tmp/second' },
+    });
+
+    assert.notEqual(runtimeInternals.workspaceManager, fakeWorkspaceManager);
+    const workspacePath = runtimeInternals.workspaceManager.resolveWorkspacePath('_old');
+    assert.equal(workspacePath.startsWith('/tmp/second/'), true);
+
   });
 });
 

--- a/src/orchestrator/runtime.ts
+++ b/src/orchestrator/runtime.ts
@@ -6,6 +6,7 @@ import type { TrackerAdapter } from '../tracker/adapter.js';
 import { renderPromptTemplate } from '../prompt/template.js';
 import type { WorkflowContract } from '../workflow/contract.js';
 import { WorkspaceManager } from '../workspace/manager.js';
+import { HookRunner } from '../workspace/hooks.js';
 export interface OrchestratorRuntime {
   tick(): Promise<void>;
 }
@@ -180,7 +181,7 @@ export class PollingRuntime implements OrchestratorRuntime {
   private failureRetryMaxDelayMs: number;
   private readonly env: Record<string, string | undefined>;
   private readonly commandExists: (command: string) => boolean;
-  private readonly workspaceManager: WorkspaceManager;
+  private workspaceManager: WorkspaceManager;
   private readonly workerFactory: (context: {
     item: NormalizedWorkItem;
     workspacePath: string;
@@ -222,17 +223,33 @@ export class PollingRuntime implements OrchestratorRuntime {
     this.reconfigureRetryPolicy(workflow);
     this.env = options.env ?? process.env;
     this.commandExists = options.commandExists ?? defaultCommandExists;
-    const workspaceRoot = this.workflow.workspace?.baseDir ?? this.workflow.workspace?.root;
+    this.workspaceManager = options.workspaceManager ?? this.buildWorkspaceManagerFromWorkflow(this.workflow);
+    this.workerFactory = options.workerFactory ?? ((context) => Promise.resolve(this.buildDefaultWorker(context)));
+  }
+
+
+  private buildWorkspaceManagerFromWorkflow(workflow: WorkflowContract): WorkspaceManager {
+    const workspaceRoot = workflow.workspace?.baseDir ?? workflow.workspace?.root;
     if (!workspaceRoot) {
       throw new Error('workspace.root is required');
     }
 
-    this.workspaceManager =
-      options.workspaceManager ??
-      new WorkspaceManager({
-        workspaceRoot,
-      });
-    this.workerFactory = options.workerFactory ?? ((context) => Promise.resolve(this.buildDefaultWorker(context)));
+    const hooks = workflow.hooks;
+    return new WorkspaceManager({
+      workspaceRoot,
+      hooks: hooks
+        ? new HookRunner({
+            hooks: {
+              after_create: hooks.after_create ?? hooks.onStart,
+              before_run: hooks.before_run,
+              after_run: hooks.after_run ?? hooks.onSuccess,
+              before_remove: hooks.before_remove,
+            },
+            timeoutMs: workflow.agent.timeouts?.hooksTimeoutMs,
+            logger: this.logger,
+          })
+        : undefined,
+    });
   }
 
   private reconfigureRetryPolicy(workflow: WorkflowContract): void {
@@ -265,7 +282,7 @@ export class PollingRuntime implements OrchestratorRuntime {
       return;
     }
 
-    const candidates = await this.tracker.listEligibleItems();
+    const candidates = await this.tracker.listCandidateItems({ activeStates: [...this.resolveActiveStates()] as WorkItemState[] });
     const sorted = sortCandidates(candidates);
     const dispatchable = sorted.filter((item) => this.isDispatchable(item.id));
     const todoBlockedByNonTerminal = await this.findTodoItemsBlockedByNonTerminal(dispatchable);
@@ -475,13 +492,40 @@ export class PollingRuntime implements OrchestratorRuntime {
   }
 
   applyWorkflow(nextWorkflow: WorkflowContract): void {
+    const prevWorkflow = this.workflow;
+    const prevWorkspaceRoot = this.workflow.workspace?.baseDir ?? this.workflow.workspace?.root;
+    const nextWorkspaceRoot = nextWorkflow.workspace?.baseDir ?? nextWorkflow.workspace?.root;
+    const prevHooks = this.workflow.hooks;
+    const nextHooks = nextWorkflow.hooks;
+
     this.workflow = nextWorkflow;
     this.reconfigureRetryPolicy(nextWorkflow);
+
+    const hooksChanged = JSON.stringify(prevHooks ?? {}) !== JSON.stringify(nextHooks ?? {});
+    if (prevWorkspaceRoot !== nextWorkspaceRoot || hooksChanged) {
+      this.workspaceManager = this.buildWorkspaceManagerFromWorkflow(nextWorkflow);
+    }
+
+    if (
+      prevWorkflow.tracker.github.owner !== nextWorkflow.tracker.github.owner ||
+      prevWorkflow.tracker.github.projectNumber !== nextWorkflow.tracker.github.projectNumber ||
+      prevWorkflow.tracker.github.tokenEnv !== nextWorkflow.tracker.github.tokenEnv
+    ) {
+      this.logger.warn('runtime.config.reloaded_but_not_applied', {
+        reason: 'tracker_config_changed',
+        previous_owner: prevWorkflow.tracker.github.owner,
+        next_owner: nextWorkflow.tracker.github.owner,
+        previous_project_number: prevWorkflow.tracker.github.projectNumber,
+        next_project_number: nextWorkflow.tracker.github.projectNumber,
+      });
+    }
+
     this.logger.info('runtime.config.applied', {
       maxConcurrency: nextWorkflow.polling.maxConcurrency ?? 1,
       pollIntervalMs: nextWorkflow.polling.intervalMs,
       continuationRetryDelayMs: this.continuationRetryDelayMs,
       failureRetryMaxDelayMs: this.failureRetryMaxDelayMs,
+      workspaceRoot: nextWorkspaceRoot,
     });
   }
 
@@ -694,7 +738,7 @@ export class PollingRuntime implements OrchestratorRuntime {
   }
 
   private async findEligibleItem(itemId: string): Promise<NormalizedWorkItem | undefined> {
-    const candidates = await this.tracker.listEligibleItems();
+    const candidates = await this.tracker.listCandidateItems({ activeStates: [...this.resolveActiveStates()] as WorkItemState[] });
     return candidates.find((item) => item.id === itemId);
   }
 

--- a/src/workflow/contract.test.ts
+++ b/src/workflow/contract.test.ts
@@ -131,6 +131,41 @@ test('buildContract surfaces validation errors clearly', () => {
   );
 });
 
+
+
+test('buildContract expands workspace path with HOME and env vars', () => {
+  process.env.WORKFLOW_TEST_ROOT = '/var/tmp/symphony-custom';
+  const doc: WorkflowDocument = {
+    config: {
+      tracker: {
+        kind: 'github_projects',
+        github: {
+          owner: 'kouka-t0yohei',
+          projectNumber: 123,
+          tokenEnv: 'GITHUB_TOKEN',
+        },
+      },
+      polling: {
+        intervalMs: 5000,
+        maxConcurrency: 1,
+      },
+      workspace: {
+        root: '$WORKFLOW_TEST_ROOT/workspaces',
+      },
+      agent: {
+        command: 'codex',
+      },
+    },
+    prompt_template: 'Run',
+  };
+
+  const contract = buildContract(doc);
+  assert.equal(contract.workspace.root, '/var/tmp/symphony-custom/workspaces');
+
+  delete process.env.WORKFLOW_TEST_ROOT;
+});
+
+
 test('FileWorkflowLoader reads file and returns contract with prompt template', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'workflow-contract-loader-'));
   const filePath = join(dir, 'WORKFLOW.md');

--- a/src/workflow/contract.ts
+++ b/src/workflow/contract.ts
@@ -1,5 +1,6 @@
 import { loadWorkflowFile, type WorkflowDocument } from './loader.js';
 
+
 export type WorkflowValidationErrorCode =
   | 'tracker.kind.required'
   | 'tracker.kind.unsupported'
@@ -147,6 +148,7 @@ export function buildContract(doc: WorkflowDocument): LoadedWorkflowContract {
   const workspaceRoot =
     coerceString(readPath(config, ['workspace', 'root'])) ??
     coerceString(readPath(config, ['workspace', 'baseDir']))!;
+  const expandedWorkspaceRoot = expandPathWithEnvironment(workspaceRoot);
 
   const hooks = (readPath(config, ['hooks']) as Record<string, unknown> | undefined) ?? {};
   const extensions =
@@ -181,8 +183,8 @@ export function buildContract(doc: WorkflowDocument): LoadedWorkflowContract {
       },
     },
     workspace: {
-      root: workspaceRoot,
-      baseDir: workspaceRoot,
+      root: expandedWorkspaceRoot,
+      baseDir: expandedWorkspaceRoot,
     },
     agent: {
       command: coerceString(readPath(config, ['agent', 'command']))!,
@@ -375,6 +377,24 @@ function readPath(input: Record<string, unknown>, path: string[]): unknown {
 
 function coerceString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+
+
+function expandPathWithEnvironment(raw: string): string {
+  let expanded = raw;
+  if (expanded.startsWith('~')) {
+    const home = process.env.HOME;
+    if (home) {
+      expanded = `${home}${expanded.slice(1)}`;
+    }
+  }
+
+  return expanded.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g, (_match, braced, plain) => {
+    const name = braced ?? plain;
+    const value = process.env[name];
+    return value ?? _match;
+  });
 }
 
 function coerceNumber(value: unknown): number | undefined {


### PR DESCRIPTION
## Summary

This PR improves SPEC alignment for the GitHub Projects backend and runtime behavior when configuration changes at runtime.

## Changes

- Update startup terminal cleanup to honor `extensions.github_projects.terminal_states`.
- Use configured active states during dispatch so `active_states` changes are effective after hot-reload.
- Enhance runtime hot-reload:
  - rebuild `WorkspaceManager` when `workspace.root`/`baseDir` changes
  - rebuild hook configuration when runtime hooks are changed
  - emit a warning when tracker identity changes (`owner`, `projectNumber`, `tokenEnv`) because tracker reconfiguration requires restart
- Expand workspace paths in workflow contract using `$VAR`, `${VAR}`, and `~`.
- Add regression tests for:
  - hot-reload behavior
  - terminal-state startup cleanup
  - workspace env expansion

## Testing

- Updated/added tests:
  - `src/bootstrap.test.ts`
  - `src/bootstrap.ts`
  - `src/orchestrator/runtime.test.ts`
  - `src/workflow/contract.test.ts`
  - `src/workflow/contract.ts`

- Full test suite: `npm test --silent`
  - Result: pass (111 tests)

- CI check currently running on PR #110; latest result to be confirmed.
