### PR TITLE
fix: support org projects and union-safe ProjectV2 queries

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -183,7 +183,7 @@ export async function bootstrapFromWorkflow(
 }
 
 function createTrackerFromWorkflow(workflow: LoadedWorkflowContract): TrackerAdapter {
-  const { owner, projectNumber, tokenEnv } = workflow.tracker.github;
+  const { owner, projectNumber, tokenEnv, type } = workflow.tracker.github;
   const token = process.env[tokenEnv]?.trim();
 
   if (!token) {
@@ -200,8 +200,8 @@ function createTrackerFromWorkflow(workflow: LoadedWorkflowContract): TrackerAda
     projectId: `owner:${owner}#${projectNumber}`,
     graphqlClient: {
       query: async <T>(queryString: string, variables?: Record<string, unknown>) => {
-        if (queryString.includes('query($projectId: ID!)') && variables?.projectId === `owner:${owner}#${projectNumber}`) {
-          const resolvedProjectId = await resolveProjectId(graphQLClient, owner, projectNumber);
+        if (queryString.includes('$projectId: ID!') && variables?.projectId === `owner:${owner}#${projectNumber}`) {
+          const resolvedProjectId = await resolveProjectId(graphQLClient, owner, projectNumber, type);
           return graphQLClient.query<T>(queryString, {
             ...(variables ?? {}),
             projectId: resolvedProjectId,
@@ -216,6 +216,7 @@ function createTrackerFromWorkflow(workflow: LoadedWorkflowContract): TrackerAda
   return new GitHubProjectsAdapter({
     owner,
     projectNumber,
+    ownerType: type,
     client: projectsClient,
     writer,
     activeStates: resolveActiveStates(workflow),
@@ -273,22 +274,30 @@ function resolveActiveStates(workflow: LoadedWorkflowContract): string[] | undef
 
 const projectIdCache = new Map<string, string>();
 
-async function resolveProjectId(client: GraphQLClient, owner: string, projectNumber: number): Promise<string> {
+async function resolveProjectId(
+  client: GraphQLClient,
+  owner: string,
+  projectNumber: number,
+  ownerType?: 'org' | 'user',
+): Promise<string> {
   const key = `${owner}#${projectNumber}`;
   const cached = projectIdCache.get(key);
   if (cached) {
     return cached;
   }
 
+  const includeUser = ownerType === 'user' || ownerType === undefined;
+  const includeOrg = ownerType === 'org' || ownerType === undefined;
+
   const data = await client.query<{
     user?: { projectV2?: { id?: string | null } | null } | null;
     organization?: { projectV2?: { id?: string | null } | null } | null;
   }>(
-    `query($owner: String!, $number: Int!) {
-      user(login: $owner) { projectV2(number: $number) { id } }
-      organization(login: $owner) { projectV2(number: $number) { id } }
+    `query($owner: String!, $number: Int!, $includeUser: Boolean!, $includeOrg: Boolean!) {
+      user(login: $owner) @include(if: $includeUser) { projectV2(number: $number) { id } }
+      organization(login: $owner) @include(if: $includeOrg) { projectV2(number: $number) { id } }
     }`,
-    { owner, number: projectNumber },
+    { owner, number: projectNumber, includeUser, includeOrg },
   );
 
   const projectId = data.user?.projectV2?.id ?? data.organization?.projectV2?.id;

--- a/src/tracker/adapter.ts
+++ b/src/tracker/adapter.ts
@@ -23,6 +23,7 @@ export interface TrackerWriter {
 export interface GitHubProjectsAdapterOptions {
   owner: string;
   projectNumber: number;
+  ownerType?: 'org' | 'user';
   client: GitHubProjectsClient;
   writer?: TrackerWriter;
   pageSize?: number;
@@ -43,6 +44,7 @@ const DEFAULT_BLOCKER_FIELD_NAMES = [
 export class GitHubProjectsAdapter implements TrackerAdapter {
   private readonly owner: string;
   private readonly projectNumber: number;
+  private readonly ownerType?: 'org' | 'user';
   private readonly client: GitHubProjectsClient;
   private readonly writer?: TrackerWriter;
   private readonly defaultPageSize: number;
@@ -52,6 +54,7 @@ export class GitHubProjectsAdapter implements TrackerAdapter {
   constructor(options: GitHubProjectsAdapterOptions) {
     this.owner = options.owner;
     this.projectNumber = options.projectNumber;
+    this.ownerType = options.ownerType;
     this.client = options.client;
     this.writer = options.writer;
     this.defaultPageSize = options.pageSize ?? 50;
@@ -90,6 +93,7 @@ export class GitHubProjectsAdapter implements TrackerAdapter {
       const page = await this.client.fetchProjectItemsPage({
         owner: this.owner,
         projectNumber: this.projectNumber,
+        ownerType: this.ownerType,
         first: pageSize,
         after,
       });

--- a/src/tracker/github-projects-client.ts
+++ b/src/tracker/github-projects-client.ts
@@ -88,6 +88,7 @@ export interface GitHubProjectsClient {
   fetchProjectItemsPage(params: {
     owner: string;
     projectNumber: number;
+    ownerType?: 'org' | 'user';
     first: number;
     after?: string;
   }): Promise<ProjectItemsPage>;
@@ -123,12 +124,13 @@ export class GitHubProjectsGraphQLClient implements GitHubProjectsClient {
   async fetchProjectItemsPage(params: {
     owner: string;
     projectNumber: number;
+    ownerType?: 'org' | 'user';
     first: number;
     after?: string;
   }): Promise<ProjectItemsPage> {
     const query = `
-      query ProjectItems($owner: String!, $number: Int!, $first: Int!, $after: String) {
-        user(login: $owner) {
+      query ProjectItems($owner: String!, $number: Int!, $first: Int!, $after: String, $includeUser: Boolean!, $includeOrg: Boolean!) {
+        user(login: $owner) @include(if: $includeUser) {
           projectV2(number: $number) {
             items(first: $first, after: $after) {
               pageInfo { hasNextPage endCursor }
@@ -151,15 +153,45 @@ export class GitHubProjectsGraphQLClient implements GitHubProjectsClient {
                     __typename
                     ... on ProjectV2ItemFieldSingleSelectValue {
                       name
-                      field { name }
+                      field {
+                        ... on ProjectV2Field {
+                          name
+                        }
+                        ... on ProjectV2SingleSelectField {
+                          name
+                        }
+                        ... on ProjectV2IterationField {
+                          name
+                        }
+                      }
                     }
                     ... on ProjectV2ItemFieldTextValue {
                       text
-                      field { name }
+                      field {
+                        ... on ProjectV2Field {
+                          name
+                        }
+                        ... on ProjectV2SingleSelectField {
+                          name
+                        }
+                        ... on ProjectV2IterationField {
+                          name
+                        }
+                      }
                     }
                     ... on ProjectV2ItemFieldNumberValue {
                       number
-                      field { name }
+                      field {
+                        ... on ProjectV2Field {
+                          name
+                        }
+                        ... on ProjectV2SingleSelectField {
+                          name
+                        }
+                        ... on ProjectV2IterationField {
+                          name
+                        }
+                      }
                     }
                   }
                 }
@@ -167,7 +199,7 @@ export class GitHubProjectsGraphQLClient implements GitHubProjectsClient {
             }
           }
         }
-        organization(login: $owner) {
+        organization(login: $owner) @include(if: $includeOrg) {
           projectV2(number: $number) {
             items(first: $first, after: $after) {
               pageInfo { hasNextPage endCursor }
@@ -190,15 +222,45 @@ export class GitHubProjectsGraphQLClient implements GitHubProjectsClient {
                     __typename
                     ... on ProjectV2ItemFieldSingleSelectValue {
                       name
-                      field { name }
+                      field {
+                        ... on ProjectV2Field {
+                          name
+                        }
+                        ... on ProjectV2SingleSelectField {
+                          name
+                        }
+                        ... on ProjectV2IterationField {
+                          name
+                        }
+                      }
                     }
                     ... on ProjectV2ItemFieldTextValue {
                       text
-                      field { name }
+                      field {
+                        ... on ProjectV2Field {
+                          name
+                        }
+                        ... on ProjectV2SingleSelectField {
+                          name
+                        }
+                        ... on ProjectV2IterationField {
+                          name
+                        }
+                      }
                     }
                     ... on ProjectV2ItemFieldNumberValue {
                       number
-                      field { name }
+                      field {
+                        ... on ProjectV2Field {
+                          name
+                        }
+                        ... on ProjectV2SingleSelectField {
+                          name
+                        }
+                        ... on ProjectV2IterationField {
+                          name
+                        }
+                      }
                     }
                   }
                 }
@@ -209,11 +271,17 @@ export class GitHubProjectsGraphQLClient implements GitHubProjectsClient {
       }
     `;
 
+    const ownerType = params.ownerType;
+    const includeUser = ownerType === 'user' || ownerType === undefined;
+    const includeOrg = ownerType === 'org' || ownerType === undefined;
+
     const data = await this.safeQuery<ProjectItemsPageQuery>(query, {
       owner: params.owner,
       number: params.projectNumber,
       first: params.first,
       after: params.after ?? null,
+      includeUser,
+      includeOrg,
     });
 
     const connection = data.user?.projectV2?.items ?? data.organization?.projectV2?.items;
@@ -253,15 +321,45 @@ export class GitHubProjectsGraphQLClient implements GitHubProjectsClient {
                 __typename
                 ... on ProjectV2ItemFieldSingleSelectValue {
                   name
-                  field { name }
+                  field {
+                        ... on ProjectV2Field {
+                          name
+                        }
+                        ... on ProjectV2SingleSelectField {
+                          name
+                        }
+                        ... on ProjectV2IterationField {
+                          name
+                        }
+                      }
                 }
                 ... on ProjectV2ItemFieldTextValue {
                   text
-                  field { name }
+                  field {
+                        ... on ProjectV2Field {
+                          name
+                        }
+                        ... on ProjectV2SingleSelectField {
+                          name
+                        }
+                        ... on ProjectV2IterationField {
+                          name
+                        }
+                      }
                 }
                 ... on ProjectV2ItemFieldNumberValue {
                   number
-                  field { name }
+                  field {
+                        ... on ProjectV2Field {
+                          name
+                        }
+                        ... on ProjectV2SingleSelectField {
+                          name
+                        }
+                        ... on ProjectV2IterationField {
+                          name
+                        }
+                      }
                 }
               }
             }


### PR DESCRIPTION
## Summary
- make project owner resolution type-aware (`org`/`user`) in tracker fetch and project ID lookup
- avoid GraphQL union selection errors by querying `field.name` through inline fragments
- ensure status-field writer resolves real project node ID for mutations

## Why
Running against organization projects (e.g. `att-devs/projects/1`) failed with:
- `Could not resolve to a User with the login ...`
- `Selections can't be made directly on unions (ProjectV2FieldConfiguration)`
- claim mutation attempts against synthetic ID `owner:<owner>#<number>`

This patch fixes those runtime blockers.

## Verification
- `npm run test -- --runInBand`
- all tests passing (111/111)
