### PR TITLE
fix: prevent runtime oversubscription beyond max_concurrency

### DIFF
--- a/src/orchestrator/runtime.test.ts
+++ b/src/orchestrator/runtime.test.ts
@@ -122,6 +122,20 @@ describe('PollingRuntime state machine', () => {
     assert.deepEqual(runtime.snapshot().running, ['A']);
   });
 
+  it('releases claimed slot after transition to running', async () => {
+    const tracker = new FakeTracker();
+    tracker.items = [item('A', 101)];
+    tracker.states.A = 'in_progress';
+
+    const runtime = new PollingRuntime(tracker, workflow, new FakeLogger(), baseRuntimeOptions);
+
+    await runtime.tick();
+
+    const snapshot = runtime.snapshot();
+    assert.deepEqual(snapshot.running, ['A']);
+    assert.deepEqual(snapshot.claimed, []);
+  });
+
   it('schedules failure retry with exponential backoff and cap', async () => {
     let now = 1_000;
     const tracker = new FakeTracker();

--- a/src/orchestrator/runtime.ts
+++ b/src/orchestrator/runtime.ts
@@ -289,7 +289,7 @@ export class PollingRuntime implements OrchestratorRuntime {
     const maxConcurrencyByState = this.resolveMaxConcurrencyByState();
 
     let dispatched = 0;
-    const capacity = Math.max(0, maxConcurrency - this.running.size);
+    const capacity = Math.max(0, maxConcurrency - this.resolveOccupiedSlots());
     for (const item of dispatchable) {
       if (dispatched >= capacity) break;
 
@@ -701,14 +701,14 @@ export class PollingRuntime implements OrchestratorRuntime {
     }
 
     const maxConcurrency = this.resolveMaxConcurrency();
-    const capacity = Math.max(0, maxConcurrency - this.running.size);
+    const capacity = Math.max(0, maxConcurrency - this.resolveOccupiedSlots());
     if (capacity <= 0) {
       this.claimed.delete(itemId);
       this.scheduleRetry(
         eligible,
         'continuation',
         'retry_fire_no_slot',
-        `no dispatch slot available (running=${this.running.size}, max=${maxConcurrency})`,
+        `no dispatch slot available (occupied=${this.resolveOccupiedSlots()}, max=${maxConcurrency})`,
       );
       return;
     }
@@ -747,6 +747,11 @@ export class PollingRuntime implements OrchestratorRuntime {
       return false;
     }
 
+    const maxConcurrency = this.resolveMaxConcurrency();
+    if (this.resolveOccupiedSlots() >= maxConcurrency) {
+      return false;
+    }
+
     this.claimed.add(item.id);
     this.logger.info('runtime.transition.claimed', {
       issue_id: item.id,
@@ -776,6 +781,7 @@ export class PollingRuntime implements OrchestratorRuntime {
         workspacePath: workspace.path,
         worker,
       });
+      this.claimed.delete(item.id);
       this.clearRetry(item.id);
 
       this.logger.info('runtime.transition.running', {
@@ -1019,6 +1025,12 @@ export class PollingRuntime implements OrchestratorRuntime {
       return DEFAULT_RUNTIME_MAX_CONCURRENCY;
     }
     return Math.max(0, Math.floor(configured));
+  }
+
+  private resolveOccupiedSlots(): number {
+    // claimed items are in-flight claims and must consume capacity until they
+    // either transition to running or fail and release the claim.
+    return this.running.size + this.claimed.size;
   }
 
   private resolveMaxConcurrencyByState(): Partial<Record<WorkItemState, number>> {


### PR DESCRIPTION
## Summary
- enforce dispatch capacity using **occupied slots** (`running + claimed`) instead of `running` only
- release `claimed` immediately when an item transitions to `running`
- add a defensive concurrency guard inside `dispatch()` to prevent oversubscription under concurrent retry fires
- add regression test: `releases claimed slot after transition to running`

## Why
In production, runtime exceeded configured `max_concurrency` (e.g. `max=2` but `running=6`) and spammed `retry_fire_no_slot`.
The root cause was capacity checks ignoring in-flight claims plus `claimed` not being cleared on successful transition.

## Verification
- `npm run test -- --runInBand`
- pass: 112/112
