### PR TITLE
docs: document GitHub Projects continuation vs done behavior

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -175,6 +175,14 @@ GitHub Projects 拡張:
 - `extensions.github_projects.project_number`
 - `extensions.github_projects.token_env`
 - `extensions.github_projects.type`
+- `extensions.github_projects.active_states`（任意、既定値: `todo`, `in_progress`, `blocked`）
+- `extensions.github_projects.terminal_states`（任意、既定値: `done`）
+- `extensions.github_projects.status_options.in_progress`（任意、既定値: `In Progress`）
+- `extensions.github_projects.status_options.done`（任意、既定値: `Done`）
+- `extensions.github_projects.mark_done_on_completion`（任意、既定値: `false`）
+
+`mark_done_on_completion: true` の場合、ワーカーが `completed` を返したら、対象アイテムを設定済み `done` の状態へ遷移させます。
+`false` のままだと、既定では短い間隔の continuation 再試行へ入り、1ターン完了の単純構成ではループに見えることがあります。
 
 古いキー（`polling.intervalMs` や `workspace.baseDir` など）との互換マッピングもあり、
 設定の自動移行をサポートします。

--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ GitHub Projects extension namespace:
 - `extensions.github_projects.project_number`
 - `extensions.github_projects.token_env`
 - `extensions.github_projects.type`
+- `extensions.github_projects.active_states` (optional, default: `todo`, `in_progress`, `blocked`)
+- `extensions.github_projects.terminal_states` (optional, default: `done`)
+- `extensions.github_projects.status_options.in_progress` (optional label text, default `In Progress`)
+- `extensions.github_projects.status_options.done` (optional label text, default `Done`)
+- `extensions.github_projects.mark_done_on_completion` (optional, default: `false`)
+
+When `mark_done_on_completion: true`, a worker completion triggers `Project` state update to your configured `done` option.
+If this is left `false`, completion will schedule a short continuation retry by default, which is expected for multi-turn workflows but can look like a loop in simple one-turn setups.
 
 Compatibility mapping is built-in for existing keys (`polling.intervalMs`, `workspace.baseDir`,
 `agent.maxTurns`, `tracker.github.*`, and camelCase timeout/retry fields), so older WORKFLOW files

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -35,6 +35,19 @@ extensions:
     type: org
     project_number: 1
     token_env: GITHUB_TOKEN
+    # Optional completion behavior
+    # - Mark item as Done automatically when worker exits completed
+    # - Keep these in sync with your board field labels
+    mark_done_on_completion: true
+    status_options:
+      in_progress: In Progress
+      done: Done
+    active_states:
+      - todo
+      - in_progress
+      - blocked
+    terminal_states:
+      - done
 ---
 
 You are working on GitHub Project item {{ issue.identifier }}.


### PR DESCRIPTION
## Summary

This PR updates the GitHub Projects configuration guidance for practical operation behavior.

Changes included:
- Document optional `mark_done_on_completion`
- Document optional `active_states` / `terminal_states`
- Document optional `status_options` mapping
- Add practical defaults in `examples/WORKFLOW.md` to mark items done on worker completion

## Why this exists

Without `mark_done_on_completion: true`, a worker that exits as `completed` enters continuation-retry behavior by design. That can appear like an unnecessary loop when your workflow is single-turn.

## Validation

- `npm test`
