### PR TITLE
feat: show live runtime in dashboard

### DIFF
--- a/src/dashboard/server.test.ts
+++ b/src/dashboard/server.test.ts
@@ -32,7 +32,7 @@ function makeSnapshot(): RuntimeStateSnapshot {
     claimed: ['item-2'],
     retryAttempts: { 'item-3': 2 },
     completed: ['item-4'],
-    runningDetails: [{ itemId: 'item-1', issueIdentifier: '#101', sessionId: 'session-1' }],
+    runningDetails: [{ itemId: 'item-1', issueIdentifier: '#101', sessionId: 'session-1', runtimeSeconds: 12 }],
     retryingDetails: [
       {
         itemId: 'item-3',
@@ -44,6 +44,7 @@ function makeSnapshot(): RuntimeStateSnapshot {
     ],
     usageTotals: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
     aggregateRuntimeSeconds: 90,
+    liveAggregateRuntimeSeconds: 102,
     latestRateLimit: { retryAfterMs: 5000, message: 'slow down' },
   };
 }
@@ -65,9 +66,11 @@ test('dashboard serves html and state json', async () => {
 
     const apiResponse = await fetch('http://127.0.0.1:43123/api/state');
     assert.equal(apiResponse.status, 200);
-    const payload = (await apiResponse.json()) as { summary: { running: number; totalTokens: number }; workflow: { owner: string } };
+    const payload = (await apiResponse.json()) as { summary: { running: number; totalTokens: number; liveAggregateRuntimeSeconds: number }; workflow: { owner: string }; running: Array<{ runtimeSeconds: number }> };
     assert.equal(payload.summary.running, 1);
     assert.equal(payload.summary.totalTokens, 15);
+    assert.equal(payload.summary.liveAggregateRuntimeSeconds, 102);
+    assert.equal(payload.running[0]?.runtimeSeconds, 12);
     assert.equal(payload.workflow.owner, 't0yohei');
   } finally {
     await server.stop();

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -27,6 +27,7 @@ interface DashboardPayload {
     inputTokens: number;
     outputTokens: number;
     aggregateRuntimeSeconds: number;
+    liveAggregateRuntimeSeconds: number;
   };
   health: {
     status: 'healthy' | 'busy';
@@ -118,6 +119,7 @@ function buildPayload(options: DashboardServerOptions): DashboardPayload {
       inputTokens: snapshot.usageTotals.inputTokens,
       outputTokens: snapshot.usageTotals.outputTokens,
       aggregateRuntimeSeconds: snapshot.aggregateRuntimeSeconds,
+      liveAggregateRuntimeSeconds: snapshot.liveAggregateRuntimeSeconds,
     },
     health: {
       status: snapshot.running.length > 0 || snapshot.retryingDetails.length > 0 ? 'busy' : 'healthy',
@@ -363,7 +365,8 @@ async function refresh() {
     metricCard('Claimed', numberFmt.format(payload.summary.claimed), 'Reserved dispatch slots'),
     metricCard('Completed', numberFmt.format(payload.summary.completed), 'Completed during this process lifetime'),
     metricCard('Total tokens', numberFmt.format(payload.summary.totalTokens), 'Input ' + numberFmt.format(payload.summary.inputTokens) + ' / Output ' + numberFmt.format(payload.summary.outputTokens)),
-    metricCard('Runtime', formatSeconds(payload.summary.aggregateRuntimeSeconds), 'Aggregate worker runtime')
+    metricCard('Runtime', formatSeconds(payload.summary.liveAggregateRuntimeSeconds), 'Live aggregate worker runtime'),
+    metricCard('Completed runtime', formatSeconds(payload.summary.aggregateRuntimeSeconds), 'Completed worker runtime only')
   ].join('');
 
   generatedAtEl.textContent = new Date(payload.generatedAt).toLocaleString();
@@ -374,10 +377,11 @@ async function refresh() {
 
   renderTable(
     runningEl,
-    ['Issue', 'Session', 'Item ID'],
+    ['Issue', 'Session', 'Runtime', 'Item ID'],
     payload.running.map((entry) => [
       escapeHtml(entry.issueIdentifier),
       escapeHtml(entry.sessionId || 'n/a'),
+      escapeHtml(formatSeconds(entry.runtimeSeconds)),
       escapeHtml(entry.itemId)
     ])
   );

--- a/src/orchestrator/runtime.live-snapshot.test.ts
+++ b/src/orchestrator/runtime.live-snapshot.test.ts
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { PollingRuntime } from './runtime.js';
+import type { WorkItemState, NormalizedWorkItem } from '../model/work-item.js';
+import type { WorkflowContract } from '../workflow/contract.js';
+import type { Logger } from '../logging/logger.js';
+import type { TrackerAdapter } from '../tracker/adapter.js';
+
+class FakeLogger implements Logger {
+  info(): void {}
+  warn(): void {}
+  error(): void {}
+}
+
+class FakeTracker implements TrackerAdapter {
+  items: NormalizedWorkItem[] = [];
+  states: Record<string, WorkItemState> = {};
+
+  async listEligibleItems(): Promise<NormalizedWorkItem[]> {
+    return this.items;
+  }
+  async listCandidateItems(): Promise<NormalizedWorkItem[]> {
+    return this.items;
+  }
+  async listItemsByStates(): Promise<NormalizedWorkItem[]> {
+    return this.items;
+  }
+  async getStatesByIds(ids: string[]): Promise<Record<string, WorkItemState>> {
+    return Object.fromEntries(ids.map((id) => [id, this.states[id] ?? 'todo']));
+  }
+  async markInProgress(): Promise<void> {}
+  async markDone(): Promise<void> {}
+}
+
+function item(id: string, number: number): NormalizedWorkItem {
+  return {
+    id,
+    number,
+    identifier: `#${number}`,
+    title: `Issue ${number}`,
+    body: '',
+    state: 'in_progress',
+    labels: [],
+    url: `https://example.com/${number}`,
+    priority: null,
+    assignees: [],
+    blocked_by: [],
+    created_at: '2026-03-08T13:00:00.000Z',
+    updated_at: '2026-03-08T13:00:00.000Z',
+  };
+}
+
+const workflow: WorkflowContract = {
+  tracker: {
+    kind: 'github_projects',
+    github: { owner: 't0yohei', projectNumber: 1, tokenEnv: 'GITHUB_TOKEN' },
+  },
+  runtime: { pollIntervalMs: 30000, maxConcurrency: 2 },
+  polling: { intervalMs: 30000, maxConcurrency: 2 },
+  workspace: { root: '/tmp/workspaces', baseDir: '/tmp/workspaces' },
+  agent: { command: 'codex' },
+};
+
+test('snapshot exposes live runtime for running entries', () => {
+  const now = 20_000;
+  const tracker = new FakeTracker();
+  const runtime = new PollingRuntime(tracker, workflow, new FakeLogger(), {
+    now: () => now,
+  });
+
+  (runtime as unknown as {
+    running: Map<string, { item: NormalizedWorkItem; startedAt: number; lastEventAt: number; workspacePath: string; sessionId?: string }>;
+    aggregateRuntimeMs: number;
+  }).running.set('A', {
+    item: item('A', 101),
+    startedAt: 5_000,
+    lastEventAt: 19_000,
+    workspacePath: '/tmp/A',
+    sessionId: 'sess-a',
+  });
+  (runtime as unknown as { aggregateRuntimeMs: number }).aggregateRuntimeMs = 4_000;
+
+  const snapshot = runtime.snapshot();
+  assert.equal(snapshot.aggregateRuntimeSeconds, 4);
+  assert.equal(snapshot.liveAggregateRuntimeSeconds, 19);
+  assert.equal(snapshot.runningDetails[0]?.runtimeSeconds, 15);
+});

--- a/src/orchestrator/runtime.test.ts
+++ b/src/orchestrator/runtime.test.ts
@@ -1012,6 +1012,7 @@ describe('PollingRuntime state machine', () => {
       totalTokens: 16,
     });
     assert.equal(snapshot.aggregateRuntimeSeconds, 10);
+    assert.equal(snapshot.liveAggregateRuntimeSeconds, 10);
     assert.equal(snapshot.latestRateLimit?.code, 'rate_limited');
     assert.equal(snapshot.latestRateLimit?.retryAfterMs, 900);
     assert.ok(snapshot.retryingDetails.some((entry) => entry.itemId === 'B' && entry.kind === 'failure'));

--- a/src/orchestrator/runtime.ts
+++ b/src/orchestrator/runtime.ts
@@ -36,10 +36,11 @@ export interface RuntimeStateSnapshot {
   claimed: string[];
   retryAttempts: Record<string, number>;
   completed: string[];
-  runningDetails: Array<{ itemId: string; issueIdentifier: string; sessionId?: string }>;
+  runningDetails: Array<{ itemId: string; issueIdentifier: string; sessionId?: string; runtimeSeconds: number }>;
   retryingDetails: Array<{ itemId: string; issueIdentifier: string; attempt: number; kind: 'continuation' | 'failure'; dueAt: string }>;
   usageTotals: RuntimeUsageTotals;
   aggregateRuntimeSeconds: number;
+  liveAggregateRuntimeSeconds: number;
   latestRateLimit?: RuntimeRateLimitSnapshot;
 }
 
@@ -468,16 +469,23 @@ export class PollingRuntime implements OrchestratorRuntime {
       retryAttempts[id] = entry.attempt;
     }
 
+    const now = this.now();
+    const aggregateRuntimeSeconds = Math.floor(this.aggregateRuntimeMs / 1000);
+    const runningDetails = [...this.running.entries()].map(([itemId, entry]) => ({
+      itemId,
+      issueIdentifier: entry.item.identifier ?? `#${entry.item.number ?? itemId}`,
+      sessionId: entry.sessionId,
+      runtimeSeconds: Math.max(0, Math.floor((now - entry.startedAt) / 1000)),
+    }));
+    const liveAggregateRuntimeSeconds =
+      aggregateRuntimeSeconds + runningDetails.reduce((sum, entry) => sum + entry.runtimeSeconds, 0);
+
     return {
       running: [...this.running.keys()],
       claimed: [...this.claimed],
       retryAttempts,
       completed: [...this.completed],
-      runningDetails: [...this.running.entries()].map(([itemId, entry]) => ({
-        itemId,
-        issueIdentifier: entry.item.identifier ?? `#${entry.item.number ?? itemId}`,
-        sessionId: entry.sessionId,
-      })),
+      runningDetails,
       retryingDetails: [...this.retry.entries()].map(([itemId, entry]) => ({
         itemId,
         issueIdentifier: entry.identifier,
@@ -486,7 +494,8 @@ export class PollingRuntime implements OrchestratorRuntime {
         dueAt: new Date(entry.dueAt).toISOString(),
       })),
       usageTotals: { ...this.usageTotals },
-      aggregateRuntimeSeconds: Math.floor(this.aggregateRuntimeMs / 1000),
+      aggregateRuntimeSeconds,
+      liveAggregateRuntimeSeconds,
       latestRateLimit: this.latestRateLimit,
     };
   }


### PR DESCRIPTION
## Summary
- expose live runtime seconds for running entries in the runtime snapshot
- use live aggregate runtime in the dashboard so active work no longer looks frozen
- add coverage for live snapshot/runtime rendering

## Testing
- npm test
- npm run lint
- npm run typecheck